### PR TITLE
Fixed MPQ load issue on french localized D2

### DIFF
--- a/core/Engine.go
+++ b/core/Engine.go
@@ -259,8 +259,11 @@ func (v *Engine) LoadFile(fileName string) []byte {
 		if !mpq.FileExists(fileName) {
 			continue
 		}
-		v.Files[fileName] = path.Join(v.Settings.MpqPath, mpqFile)
 		result, _ := mpq.ReadFile(fileName)
+		if len(result) == 0 {
+			continue
+		}
+		v.Files[fileName] = path.Join(v.Settings.MpqPath, mpqFile)
 		return result
 	}
 	log.Fatalf("Could not load %s from MPQs", fileName)

--- a/mpq/MPQ.go
+++ b/mpq/MPQ.go
@@ -227,7 +227,7 @@ func (v MPQ) getFileHashEntry(fileName string) (HashTableEntry, error) {
 func (v MPQ) GetFileBlockData(fileName string) (BlockTableEntry, error) {
 	fileName = strings.ReplaceAll(fileName, "{LANG}", resourcepaths.LanguageCode)
 	fileEntry, err := v.getFileHashEntry(fileName)
-	if err != nil {
+	if err != nil || fileEntry.BlockIndex >= uint32(len(v.BlockTableEntries)) {
 		return BlockTableEntry{}, err
 	}
 	return v.BlockTableEntries[fileEntry.BlockIndex], nil


### PR DESCRIPTION
This PR fixes an issue in some copies where a file would match an mpq, but return a 0-byte file entry. It will now treat this as a 'file not found' and keep looking.