### PR TITLE
Check if MPQ file was loaded before reading.

### DIFF
--- a/core/Engine.go
+++ b/core/Engine.go
@@ -105,6 +105,9 @@ func (v *Engine) LoadFile(fileName string) []byte {
 	}
 	for _, mpqFile := range v.Settings.MpqLoadOrder {
 		archive, _ := mpq.Load(path.Join(v.Settings.MpqPath, mpqFile))
+		if archive == nil {
+			log.Fatalf("Failed to load specified MPQ file: %s", mpqFile)
+		}
 		if !archive.FileExists(fileName) {
 			continue
 		}


### PR DESCRIPTION
And if it wasn't then tell the user which one instead of crashing.