### PR TITLE
Closes Issue#176

### DIFF
--- a/d2core/d2scene/credits.go
+++ b/d2core/d2scene/credits.go
@@ -67,7 +67,7 @@ func (v *Credits) LoadContributors() []string {
 	contributors := []string{}
 	file, err := os.Open(path.Join("./", "CONTRIBUTORS"))
 	if err != nil {
-		log.Fatal("CONTRIBUTORS file is missing")
+		log.Print("CONTRIBUTORS file is missing")
 	}
 	defer file.Close()
 


### PR DESCRIPTION
"Fatal is equivalent to Print() followed by a call to os.Exit(1)." This is why it is crashing.