### PR TITLE
Adjust sub-tile rendering offset.

### DIFF
--- a/d2render/animated_entity.go
+++ b/d2render/animated_entity.go
@@ -172,7 +172,7 @@ func (v *AnimatedEntity) Render(target *ebiten.Image, offsetX, offsetY int) {
 
 		// Location within the current tile
 		localX := (v.subcellX - v.subcellY) * 16
-		localY := ((v.subcellX + v.subcellY) * 8) - 4
+		localY := ((v.subcellX + v.subcellY) * 8) - 5
 
 		// TODO: Transparency op maybe, but it'l murder batch calls
 		opts := &ebiten.DrawImageOptions{}


### PR DESCRIPTION
-5 Y when rendering based on sub-tile matches real D2 (at least for
rendering act 1 stash)