### PR TITLE
Visual Studio Code extension recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/*__debug_bin
 .vscode/**/*
+!.vscode/extensions.json
 **/Client.exe
 **/Client
 .idea/**/*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-vscode.go",
+        "defaltd.go-coverage-viewer"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ The following extensions are recommended for working with this project:
 -   ms-vscode.go
 -   defaltd.go-coverage-viewer
 
-You can get to it by going to settings <kbd>Ctrl+,</kbd>, expanding `Extensions` and selecting `Go configuration`,
+When you open the workspace for the first time, Visual Studio Code will automatically suggest these extensions for installation.
+
+Alternatively you can get to it by going to settings <kbd>Ctrl+,</kbd>, expanding `Extensions` and selecting `Go configuration`,
 then clicking on `Edit in settings.json`. Just paste that section where appropriate.
 
 ## Configuration


### PR DESCRIPTION
After accepting this pull request Visual Studio Code will recommend the extensions *ms-vscode.go* and *defaltd.go-coverage-viewer* allowing the user to download and install them automatically.