### PR TITLE
Prevent some map load crashes.

### DIFF
--- a/d2render/animated_entity.go
+++ b/d2render/animated_entity.go
@@ -161,7 +161,7 @@ func (v *AnimatedEntity) Render(target *ebiten.Image, offsetX, offsetY int) {
 			}
 		}
 	}
-	if v.currentFrame < 0 || v.frames == nil || v.currentFrame > len(v.frames) || v.frames[v.currentFrame] == nil {
+	if v.currentFrame < 0 || v.frames == nil || v.currentFrame >= len(v.frames) || v.frames[v.currentFrame] == nil {
 		return
 	}
 	localX := (v.subcellX - v.subcellY) * 16
@@ -248,7 +248,7 @@ func (v *AnimatedEntity) updateFrameCache() {
 			if v.Cof.CofLayers[cofLayerIdx].Transparent {
 				transparency = byte(128)
 			}
-			if animationIdx > len(dccLayer.Directions[v.direction].Frames) {
+			if animationIdx >= len(dccLayer.Directions[v.direction].Frames) {
 				log.Printf("Invalid animation index of %d for animated entity", animationIdx)
 				continue
 			}

--- a/d2render/d2mapengine/region.go
+++ b/d2render/d2mapengine/region.go
@@ -203,6 +203,9 @@ func (v *Region) renderWall(tile d2ds1.WallRecord, offsetX, offsetY int, target 
 	img := v.GetImageCacheRecord(tile.MainIndex, tile.SubIndex, tile.Orientation)
 	if img == nil {
 		img = v.generateWallCache(tile)
+		if img == nil {
+			return
+		}
 	}
 	tileData := v.getTile(int32(tile.MainIndex), int32(tile.SubIndex), int32(tile.Orientation))
 	if tileData == nil {


### PR DESCRIPTION
This PR prevents a few map load crashes. There are some DS1 loader errors that will still crash, but this should at least make most of the maps load successfully (if not accurately).