### PR TITLE
Attempt to fix OpenDiablo2 deploy to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,12 @@ git:
   depth: 1
 notifications:
   email: false
+before_deploy:
+  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
+  - git tag $TRAVIS_TAG
 deploy:
   provider: releases
-  api_key:
-    secure: "$GithubApi"
+  edge: true
   file_glob: true
   file: opendiablo2-$TRAVIS_TAG-$TRAVIS_OS_NAME.*
   skip_cleanup: true
@@ -39,4 +41,4 @@ deploy:
   name: "OpenDiablo Unstable (Build $TRAVIS_BUILD_NUMBER)"
   prerelease: true
   on:
-    tags: true
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ before_deploy:
   - git tag $TRAVIS_TAG
 deploy:
   provider: releases
-  edge: true
+  api_key:
+    secure: "$GithubApi"
   file_glob: true
   file: opendiablo2-$TRAVIS_TAG-$TRAVIS_OS_NAME.*
   skip_cleanup: true


### PR DESCRIPTION
Hi, 

I saw that there was an issue with deploying master.  This addresses issue #142 

**Description**
In this PR, we are adding the ability to release the master branch.  This creates a Draft of a release which the maintainers and owners will have to approve.  Similar to whats here:  
https://github.com/zelahi/OpenDiablo2/releases

This release was created by the job here: 
https://travis-ci.com/zelahi/OpenDiablo2/builds/137299338