### PR TITLE
Animate floor tiles

### DIFF
--- a/d2render/d2mapengine/engine.go
+++ b/d2render/d2mapengine/engine.go
@@ -185,6 +185,7 @@ func (v *Engine) RenderRegion(region EngineRegion, target *ebiten.Image) {
 	for tileIdx := range region.Tiles {
 		sx, sy := d2helper.IsoToScreen(region.Tiles[tileIdx].tileX+region.Rect.Left, region.Tiles[tileIdx].tileY+region.Rect.Top, int(v.OffsetX), int(v.OffsetY))
 		if sx > -160 && sy > -380 && sx <= 880 && sy <= 1240 {
+			region.Region.UpdateAnimations()
 			v.RenderPass1(region.Region, region.Tiles[tileIdx].offX, region.Tiles[tileIdx].offY, region.Tiles[tileIdx].tileX, region.Tiles[tileIdx].tileY, target)
 			if v.ShowTiles > 0 {
 				v.DrawTileLines(region.Region, region.Tiles[tileIdx].offX, region.Tiles[tileIdx].offY, region.Tiles[tileIdx].tileX, region.Tiles[tileIdx].tileY, target)

--- a/d2render/d2mapengine/region.go
+++ b/d2render/d2mapengine/region.go
@@ -306,7 +306,7 @@ func (v *Region) decodeTileGfxData(blocks []d2dt1.Block, pixels *[]byte, tileYOf
 	}
 }
 
-func (v *Region) generateFloorCache(tile *d2ds1.FloorShadowRecord, tileX, tileY int) *ebiten.Image {
+func (v *Region) generateFloorCache(tile *d2ds1.FloorShadowRecord, tileX, tileY int) {
 	tileOptions := v.getTiles(int32(tile.Style), int32(tile.Sequence), 0, tileX, tileY, v.seed)
 	tileIndex := v.getRandomTile(tileOptions, tileX, tileY, v.seed)
 	tileData := &tileOptions[tileIndex]
@@ -320,7 +320,7 @@ func (v *Region) generateFloorCache(tile *d2ds1.FloorShadowRecord, tileX, tileY 
 	tile.RandomIndex = tileIndex
 	cachedImage := v.GetImageCacheRecord(tile.Style, tile.Sequence, 0, tileIndex)
 	if cachedImage != nil {
-		return cachedImage
+		return
 	}
 	tileYMinimum := int32(0)
 	for _, block := range tileData.Blocks {
@@ -333,16 +333,15 @@ func (v *Region) generateFloorCache(tile *d2ds1.FloorShadowRecord, tileX, tileY 
 	v.decodeTileGfxData(tileData.Blocks, &pixels, tileYOffset, tileData.Width)
 	image.ReplacePixels(pixels)
 	v.SetImageCacheRecord(tile.Style, tile.Sequence, 0, tileIndex, image)
-	return image
 }
 
-func (v *Region) generateShadowCache(tile *d2ds1.FloorShadowRecord, tileX, tileY int) *ebiten.Image {
+func (v *Region) generateShadowCache(tile *d2ds1.FloorShadowRecord, tileX, tileY int) {
 	tileOptions := v.getTiles(int32(tile.Style), int32(tile.Sequence), 13, tileX, tileY, v.seed)
 	tileIndex := v.getRandomTile(tileOptions, tileX, tileY, v.seed)
 	tileData := &tileOptions[tileIndex]
 
 	if tileData == nil {
-		return nil
+		return
 	}
 	tile.RandomIndex = tileIndex
 	tileMinY := int32(0)
@@ -357,7 +356,7 @@ func (v *Region) generateShadowCache(tile *d2ds1.FloorShadowRecord, tileX, tileY
 
 	cachedImage := v.GetImageCacheRecord(tile.Style, tile.Sequence, 13, tileIndex)
 	if cachedImage != nil {
-		return cachedImage
+		return
 	}
 
 	image, _ := ebiten.NewImage(int(tileData.Width), int(tileHeight), ebiten.FilterNearest)
@@ -365,15 +364,14 @@ func (v *Region) generateShadowCache(tile *d2ds1.FloorShadowRecord, tileX, tileY
 	v.decodeTileGfxData(tileData.Blocks, &pixels, tileYOffset, tileData.Width)
 	image.ReplacePixels(pixels)
 	v.SetImageCacheRecord(tile.Style, tile.Sequence, 13, tileIndex, image)
-	return image
 }
 
-func (v *Region) generateWallCache(tile *d2ds1.WallRecord, tileX, tileY int) *ebiten.Image {
+func (v *Region) generateWallCache(tile *d2ds1.WallRecord, tileX, tileY int) {
 	tileOptions := v.getTiles(int32(tile.Style), int32(tile.Sequence), int32(tile.Type), tileX, tileY, v.seed)
 	tileIndex := v.getRandomTile(tileOptions, tileX, tileY, v.seed)
 	tileData := &tileOptions[tileIndex]
 	if tileData == nil {
-		return nil
+		return
 	}
 
 	tile.RandomIndex = tileIndex
@@ -411,12 +409,12 @@ func (v *Region) generateWallCache(tile *d2ds1.WallRecord, tileX, tileY int) *eb
 
 	cachedImage := v.GetImageCacheRecord(tile.Style, tile.Sequence, tile.Type, tileIndex)
 	if cachedImage != nil {
-		return cachedImage
+		return
 	}
 
 	if realHeight == 0 {
 		log.Printf("Invalid 0 height for wall tile")
-		return nil
+		return
 	}
 
 	image, _ := ebiten.NewImage(160, int(realHeight), ebiten.FilterNearest)
@@ -432,7 +430,6 @@ func (v *Region) generateWallCache(tile *d2ds1.WallRecord, tileX, tileY int) *eb
 	}
 
 	v.SetImageCacheRecord(tile.Style, tile.Sequence, tile.Type, tileIndex, image)
-	return image
 }
 
 func (v *Region) GetImageCacheRecord(style, sequence byte, tileType d2enum.TileType, randomIndex byte) *ebiten.Image {

--- a/d2render/d2mapengine/region.go
+++ b/d2render/d2mapengine/region.go
@@ -91,6 +91,7 @@ func LoadRegion(seed int64, levelType d2enum.RegionIdType, levelPreset int, file
 	result.DS1 = d2ds1.LoadDS1("/data/global/tiles/"+levelFile, fileProvider)
 	result.TileWidth = result.DS1.Width
 	result.TileHeight = result.DS1.Height
+	result.currentFrame = 0
 	result.loadObjects(fileProvider)
 	result.loadSpecials()
 	return result
@@ -142,11 +143,12 @@ func (v *Region) UpdateAnimations() {
 	framesToAdd := math.Floor((now - v.lastFrameTime) / 0.1)
 	if framesToAdd > 0 {
 		v.lastFrameTime += 0.1 * framesToAdd
-		v.currentFrame -= byte(math.Floor(framesToAdd))
-		for v.currentFrame <= 0 {
-			v.currentFrame = 9
+		v.currentFrame += byte(math.Floor(framesToAdd))
+		if v.currentFrame > 9 {
+			v.currentFrame = 0
 		}
 	}
+	log.Printf("current frame %v", v.currentFrame)
 }
 
 func (v *Region) RenderTile(offsetX, offsetY, tileX, tileY int, layerType d2enum.RegionLayerType, layerIndex int, target *ebiten.Image) {
@@ -208,8 +210,6 @@ func (v *Region) getTiles(style, sequence, tileType int32, x, y int, seed int64)
 		log.Printf("Unknown tile ID [%d %d %d]\n", style, sequence, tileType)
 		return nil
 	}
-	//	index := v.getRandomTile(tiles, x, y, seed)
-	//	return &tiles[index], index
 	return tiles
 }
 
@@ -332,7 +332,7 @@ func (v *Region) generateFloorCache(tile *d2ds1.FloorShadowRecord, tileX, tileY 
 
 	if tileOptions == nil {
 		log.Printf("Could not locate tile Style:%d, Seq: %d, Type: %d\n", tile.Style, tile.Sequence, 0)
-		tileData[0] = &d2dt1.Tile{}
+		tileData = append(tileData, &d2dt1.Tile{})
 		tileData[0].Width = 10
 		tileData[0].Height = 10
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenDiablo2/OpenDiablo2
 go 1.12
 
 require (
-	github.com/OpenDiablo2/D2Shared v0.0.0-20191123042841-db10113a19d4
+	github.com/OpenDiablo2/D2Shared v0.0.0-20191124053203-a445d5d8cbe0
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/hajimehoshi/ebiten v1.11.0-alpha.0.20191121152720-3df198f68eea

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/JoshVarga/blast v0.0.0-20180421040937-681c804fb9f0 h1:tDnuU0igiBiQFjsvq1Bi7DpoUjqI76VVvW045vpeFeM=
 github.com/JoshVarga/blast v0.0.0-20180421040937-681c804fb9f0/go.mod h1:h/5OEGj4G+fpYxluLjSMZbFY011ZxAntO98nCl8mrCs=
-github.com/OpenDiablo2/D2Shared v0.0.0-20191123042841-db10113a19d4 h1:JORv3nRZeMrQt5jpBd6IX6NXhJCgHSIv+Yzt1tBBMxo=
-github.com/OpenDiablo2/D2Shared v0.0.0-20191123042841-db10113a19d4/go.mod h1:zRNOUiglwakbufN8EsNWqLLDHsZoQDA6/dI2GIu2nnU=
+github.com/OpenDiablo2/D2Shared v0.0.0-20191124053203-a445d5d8cbe0 h1:AvMIpYAhSC3xpDwAHHXUt8LN75oeH3sHrzXys/DgJU4=
+github.com/OpenDiablo2/D2Shared v0.0.0-20191124053203-a445d5d8cbe0/go.mod h1:zRNOUiglwakbufN8EsNWqLLDHsZoQDA6/dI2GIu2nnU=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=


### PR DESCRIPTION
Caches all frames for animated tiles on region load.

The region keeps track of the current frame of animation and updates it when requested to by the engine. The render function then simply uses the index in the cache to get the corresponding frame.