### PR TITLE
Add asset manager

### DIFF
--- a/d2core/asset_manager.go
+++ b/d2core/asset_manager.go
@@ -109,30 +109,6 @@ func (am *assetManager) loadArchive(archivePath string, cache bool) (*d2mpq.MPQ,
 	return archive, nil
 }
 
-func (am *assetManager) loadArchive(archivePath string, cache bool) (*d2mpq.MPQ, error) {
-	if archive, found := am.archiveCache.retrieve(archivePath); found {
-		return archive.(*d2mpq.MPQ), nil
-	}
-
-	archive, err := d2mpq.Load(archivePath)
-	if err != nil {
-		return nil, err
-	}
-
-	if cache {
-		stat, err := os.Stat(archivePath)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := am.archiveCache.insert(archivePath, archive, int(stat.Size())); err != nil {
-			return nil, err
-		}
-	}
-
-	return archive, nil
-}
-
 func (am *assetManager) fixupFilePath(filePath string) string {
 	filePath = strings.ReplaceAll(filePath, "{LANG}", am.config.Language)
 	if strings.ToUpper(d2resource.LanguageCode) == "CHI" {

--- a/d2core/asset_manager.go
+++ b/d2core/asset_manager.go
@@ -1,0 +1,149 @@
+package d2core
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/OpenDiablo2/D2Shared/d2common/d2resource"
+	"github.com/OpenDiablo2/D2Shared/d2data/d2mpq"
+	"github.com/OpenDiablo2/OpenDiablo2/d2corecommon"
+)
+
+type assetManager struct {
+	fileCache     *cache
+	archiveCache  *cache
+	archiveLookup map[string]string
+	config        *d2corecommon.Configuration
+	mutex         sync.Mutex
+}
+
+func createAssetManager(config *d2corecommon.Configuration) *assetManager {
+	return &assetManager{
+		fileCache:     createCache(1024 * 1024 * 32),
+		archiveCache:  createCache(1024 * 1024 * 512),
+		archiveLookup: make(map[string]string),
+		config:        config,
+	}
+}
+
+func (am *assetManager) LoadFile(filePath string) []byte {
+	data, err := am.loadFile(am.fixupFilePath(filePath))
+	if err != nil {
+		log.Println(err)
+	}
+
+	return data
+}
+
+func (am *assetManager) loadFile(filePath string) ([]byte, error) {
+	if value, found := am.fileCache.retrieve(filePath); found {
+		return value.([]byte), nil
+	}
+
+	archive, err := am.findArchiveForFilePath(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := archive.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := am.fileCache.insert(filePath, data, len(data)); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (am *assetManager) findArchiveForFilePath(filePath string) (*d2mpq.MPQ, error) {
+	am.mutex.Lock()
+	defer am.mutex.Unlock()
+
+	if archivePath, found := am.archiveLookup[filePath]; found {
+		return am.loadArchive(archivePath, true)
+	}
+
+	for _, archiveName := range am.config.MpqLoadOrder {
+		archivePath := path.Join(am.config.MpqPath, archiveName)
+		archive, err := am.loadArchive(archivePath, false)
+		if err != nil {
+			return nil, err
+		}
+
+		if archive.FileExists(filePath) {
+			am.archiveLookup[filePath] = archivePath
+			return archive, nil
+		}
+	}
+
+	return nil, fmt.Errorf("file not found: %s", filePath)
+}
+
+func (am *assetManager) loadArchive(archivePath string, cache bool) (*d2mpq.MPQ, error) {
+	if archive, found := am.archiveCache.retrieve(archivePath); found {
+		return archive.(*d2mpq.MPQ), nil
+	}
+
+	archive, err := d2mpq.Load(archivePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if cache {
+		stat, err := os.Stat(archivePath)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := am.archiveCache.insert(archivePath, archive, int(stat.Size())); err != nil {
+			return nil, err
+		}
+	}
+
+	return archive, nil
+}
+
+func (am *assetManager) loadArchive(archivePath string, cache bool) (*d2mpq.MPQ, error) {
+	if archive, found := am.archiveCache.retrieve(archivePath); found {
+		return archive.(*d2mpq.MPQ), nil
+	}
+
+	archive, err := d2mpq.Load(archivePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if cache {
+		stat, err := os.Stat(archivePath)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := am.archiveCache.insert(archivePath, archive, int(stat.Size())); err != nil {
+			return nil, err
+		}
+	}
+
+	return archive, nil
+}
+
+func (am *assetManager) fixupFilePath(filePath string) string {
+	filePath = strings.ReplaceAll(filePath, "{LANG}", am.config.Language)
+	if strings.ToUpper(d2resource.LanguageCode) == "CHI" {
+		filePath = strings.ReplaceAll(filePath, "{LANG_FONT}", am.config.Language)
+	} else {
+		filePath = strings.ReplaceAll(filePath, "{LANG_FONT}", "latin")
+	}
+
+	filePath = strings.ToLower(filePath)
+	filePath = strings.ReplaceAll(filePath, `/`, "\\")
+	filePath = strings.TrimPrefix(filePath, "\\")
+
+	return filePath
+}

--- a/d2core/cache.go
+++ b/d2core/cache.go
@@ -1,0 +1,97 @@
+package d2core
+
+import (
+	"errors"
+	"sync"
+)
+
+type cacheNode struct {
+	next   *cacheNode
+	prev   *cacheNode
+	key    string
+	value  interface{}
+	weight int
+}
+
+type cache struct {
+	head   *cacheNode
+	tail   *cacheNode
+	lookup map[string]*cacheNode
+	weight int
+	budget int
+	mutex  sync.Mutex
+}
+
+func createCache(budget int) *cache {
+	return &cache{lookup: make(map[string]*cacheNode), budget: budget}
+}
+
+func (c *cache) insert(key string, value interface{}, weight int) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if _, found := c.lookup[key]; found {
+		return errors.New("key already exists in cache")
+	}
+
+	node := &cacheNode{
+		key:    key,
+		value:  value,
+		weight: weight,
+		next:   c.head,
+	}
+
+	if c.head != nil {
+		c.head.prev = node
+	}
+
+	c.head = node
+	if c.tail == nil {
+		c.tail = node
+	}
+
+	c.lookup[key] = node
+	c.weight += node.weight
+
+	for ; c.tail != nil && c.tail != c.head && c.weight > c.budget; c.tail = c.tail.prev {
+		c.weight -= c.tail.weight
+		c.tail.prev.next = nil
+		delete(c.lookup, c.tail.key)
+	}
+
+	return nil
+}
+
+func (c *cache) retrieve(key string) (interface{}, bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	node, found := c.lookup[key]
+	if !found {
+		return nil, false
+	}
+
+	if node != c.head {
+		if node.next != nil {
+			node.next.prev = node.prev
+		}
+		if node.prev != nil {
+			node.prev.next = node.next
+		}
+
+		if node == c.tail {
+			c.tail = c.tail.prev
+		}
+
+		node.next = c.head
+		node.prev = nil
+
+		if c.head != nil {
+			c.head.prev = node
+		}
+
+		c.head = node
+	}
+
+	return node.value, true
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenDiablo2/OpenDiablo2
 go 1.12
 
 require (
-	github.com/OpenDiablo2/D2Shared v0.0.0-20191215185943-ef5f17453dfd
+	github.com/OpenDiablo2/D2Shared v0.0.0-20191217031331-027f7bbcb9fc
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/hajimehoshi/ebiten v1.11.0-alpha.0.20191121152720-3df198f68eea

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/JoshVarga/blast v0.0.0-20180421040937-681c804fb9f0 h1:tDnuU0igiBiQFjs
 github.com/JoshVarga/blast v0.0.0-20180421040937-681c804fb9f0/go.mod h1:h/5OEGj4G+fpYxluLjSMZbFY011ZxAntO98nCl8mrCs=
 github.com/OpenDiablo2/D2Shared v0.0.0-20191215185943-ef5f17453dfd h1:f7THoOT1W1BTaSm/hwz9S/THw0ZLkuYQI9BLV1Pa+Iw=
 github.com/OpenDiablo2/D2Shared v0.0.0-20191215185943-ef5f17453dfd/go.mod h1:mY8Ll5/iLRAQsaHvIdqSZiHX3aFCys/Q4Sot+xYpero=
+github.com/OpenDiablo2/D2Shared v0.0.0-20191217031331-027f7bbcb9fc h1:f+PIG0HmaNYzBZuWuJAVau8SnllRLbzv6O8ttADXKrY=
+github.com/OpenDiablo2/D2Shared v0.0.0-20191217031331-027f7bbcb9fc/go.mod h1:mY8Ll5/iLRAQsaHvIdqSZiHX3aFCys/Q4Sot+xYpero=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=


### PR DESCRIPTION
Handles in-memory caching of frequently used files, MPQ archives. Memory budgets can be set to determine when files get evicted from the cache and have to be reloaded from disk.
