### PR TITLE
Added runtime check for 32-bit windows.

### DIFF
--- a/d2corecommon/configuration.go
+++ b/d2corecommon/configuration.go
@@ -110,6 +110,11 @@ func getDefaultConfiguration() *Configuration {
 	}
 
 	switch runtime.GOOS {
+	case "windows":
+		switch runtime.GOARCH {
+		case "386":
+			config.MpqPath = "C:/Program Files/Diablo II"
+		}
 	case "darwin":
 		config.MpqPath = "/Applications/Diablo II/"
 		config.MpqLoadOrder = []string{


### PR DESCRIPTION
Just updates the default config to point to `C:\Program Files` instead of `C:\Program Files (x86)`.