### PR TITLE
adding event bus, not currently used anywhere

### DIFF
--- a/d2core/d2event/d2event.go
+++ b/d2core/d2event/d2event.go
@@ -1,0 +1,42 @@
+package d2event
+
+import (
+	"errors"
+	"log"
+	"github.com/kataras/go-events"
+)
+
+var (
+	ErrWasInit         = errors.New("Event bus is already initialized")
+	ErrNotInit         = errors.New("Event bus has not been initialized")
+)
+
+var singleton events.EventEmmiter
+
+func Initialize() error {
+	verifyNotInit()
+
+	singleton = events.New()
+	log.Printf("Initialized the Event Bus...")
+	return nil
+}
+
+func Emit(key string, data ...interface{}) {
+	singleton.Emit(events.EventName(key), data...)
+}
+
+func On(key string, fn func(payload ...interface{})) {
+	singleton.On(events.EventName(key), fn)
+}
+
+func verifyWasInit() {
+	if singleton == nil {
+		panic(ErrNotInit)
+	}
+}
+
+func verifyNotInit() {
+	if singleton != nil {
+		panic(ErrWasInit)
+	}
+}

--- a/d2core/d2event/game_events.go
+++ b/d2core/d2event/game_events.go
@@ -1,0 +1,99 @@
+package d2event
+
+type gameEvent int
+
+const (
+	GamePause				gameEvent = iota
+	GameResume
+	GameSaveAndExit
+
+	ViewToggleTerminal
+	ViewShowTerminal
+	ViewHideTerminal
+
+	ViewToggleMainMenu
+	ViewShowMainMenu
+	ViewHideMainMenu
+
+	ViewToggleCharacter
+	ViewShowCharacter
+	ViewHideCharacter
+
+	ViewToggleInventory
+	ViewShowInventory
+	ViewHideInventory
+
+	ViewToggleParty
+	ViewShowParty
+	ViewHideParty
+
+	ViewToggleHireling
+	ViewShowHireling
+	ViewHideHireling
+
+	ViewToggleMessage
+	ViewShowMessage
+	ViewHideMessage
+
+	ViewToggleQuests
+	ViewShowQuests
+	ViewHideQuests
+
+	ViewToggleSkillTree
+	ViewShowSkillTree
+	ViewHideSkillTree
+
+	ViewToggleSkillBarLeft
+	ViewShowSkillBarLeft
+	ViewHideSkillBarLeft
+
+	ViewToggleSkillBarRight
+	ViewShowSkillBarRight
+	ViewHideSkillBarRight
+
+	ViewToggleMap
+	ViewShowMap
+	ViewHideMap
+
+	ViewToggleChat
+	ViewShowChat
+	ViewHideChat
+
+	ViewToggleItems
+	ViewShowItems
+	ViewHideItems
+
+	ViewTogglePortraits
+	ViewShowPortraits
+	ViewHidePortraits
+
+	CharExpAdd
+	CharExpRemove
+
+	CharLvlSet
+
+	CharPointStatGive
+	CharPointStatAllocate
+	CharPointStatReset
+
+	CharPointSkillGive
+	CharPointSkillAllocate
+	CharPointSkillReset
+
+	SkillTreeEnable
+	SkillTreeDisable
+
+	EquipHelm
+	EquipArmor
+	EquipBelt
+	EquipGloves
+	EquipBoots
+	EquipWieldLeft
+	EquipWieldRight
+	EquipRingLeft
+	EquipRingRight
+	EquipAmulet
+	EquipOffhandLeft
+	EquipOffhandRight
+)
+

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	ebiten2 "github.com/OpenDiablo2/OpenDiablo2/d2core/d2audio/ebiten"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2config"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2event"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2input"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2render"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2render/ebiten"
@@ -73,6 +74,10 @@ func main() {
 }
 
 func initialize() error {
+	if err := d2event.Initialize(); err != nil {
+		return err
+	}
+
 	singleton.timeScale = 1.0
 	singleton.lastTime = d2common.Now()
 


### PR DESCRIPTION
Provides a global event bus, exports `On(string, func(payload ...interface{}))` and `Emit(string, payload ...interface{})`.

I started listing events, but didn't really finish it. Don't even know if that would be the right place to put them.