### PR TITLE
all: use goimports to format code and fix two minor typos in comments

### DIFF
--- a/d2common/calcstring.go
+++ b/d2common/calcstring.go
@@ -1,9 +1,9 @@
 package d2common
 
-// a calcstring is a type of string often used in datafiles to specify 
+// a calcstring is a type of string often used in datafiles to specify
 // a value that is calculated dynamically based on the stats of the relevant
 // source, for instance a missile might have a movement speed of lvl*2
 
-type CalcString string 
+type CalcString string
 
 // todo: the logic for parsing these should exist here

--- a/d2common/d2data/d2compression/huffman.go
+++ b/d2common/d2data/d2compression/huffman.go
@@ -263,7 +263,7 @@ func adjustTree(newNode *linkedNode) {
 			continue
 		}
 
-		// The following code basicly swaps insertpoint with current
+		// The following code basically swaps insertpoint with current
 
 		// remove insert point
 		if insertpoint.Prev != nil {

--- a/d2common/d2data/d2datadict/object_lookup.go
+++ b/d2common/d2data/d2datadict/object_lookup.go
@@ -1,6 +1,5 @@
 package d2datadict
 
-
 var objectLookups = []ObjectLookupRecord{
 	{Act: 1, Type: ObjectTypeCharacter, Id: 0, Description: "gheed-ACT 1 TABLE", ObjectsTxtId: -1, MonstatsTxtId: -1, Direction: -1, Base: "/Data/Global/Monsters", Token: "GH", Mode: "NU", Class: "HTH", TR: "LIT", Index: -1},
 	{Act: 1, Type: ObjectTypeCharacter, Id: 1, Description: "cain1-ACT 1 TABLE", ObjectsTxtId: -1, MonstatsTxtId: -1, Direction: -1, Base: "/Data/Global/Monsters", Token: "DC", Mode: "NU", Class: "HTH", TR: "LIT", Index: -1},

--- a/d2common/d2data/d2datadict/object_query_test.go
+++ b/d2common/d2data/d2datadict/object_query_test.go
@@ -1,8 +1,9 @@
 package d2datadict
 
 import (
-	testify "github.com/stretchr/testify/assert"
 	"testing"
+
+	testify "github.com/stretchr/testify/assert"
 )
 
 // Verify the lookup returns the right object after indexing.

--- a/d2common/d2fileformats/d2dt1/subtile.go
+++ b/d2common/d2fileformats/d2dt1/subtile.go
@@ -1,17 +1,17 @@
 package d2dt1
 
 type SubTileFlags struct {
-	BlockWalk bool
-	BlockLOS bool
-	BlockJump bool
+	BlockWalk       bool
+	BlockLOS        bool
+	BlockJump       bool
 	BlockPlayerWalk bool
-	Unknown1 bool
-	BlockLight bool
-	Unknown2 bool
-	Unknown3 bool
+	Unknown1        bool
+	BlockLight      bool
+	Unknown2        bool
+	Unknown3        bool
 }
 
-func (s* SubTileFlags) DebugString() string {
+func (s *SubTileFlags) DebugString() string {
 	result := ""
 	if s.BlockWalk {
 		result += "BlockWalk "
@@ -42,13 +42,13 @@ func (s* SubTileFlags) DebugString() string {
 
 func NewSubTileFlags(data byte) SubTileFlags {
 	return SubTileFlags{
-		BlockWalk:       data & 1 == 1,
-		BlockLOS:        data & 2 == 2,
-		BlockJump:       data & 4 == 4,
-		BlockPlayerWalk: data & 8 == 8,
-		Unknown1:        data & 16 == 16,
-		BlockLight:      data & 32 == 32,
-		Unknown2:        data & 64 == 64,
-		Unknown3:        data & 128 == 128,
+		BlockWalk:       data&1 == 1,
+		BlockLOS:        data&2 == 2,
+		BlockJump:       data&4 == 4,
+		BlockPlayerWalk: data&8 == 8,
+		Unknown1:        data&16 == 16,
+		BlockLight:      data&32 == 32,
+		Unknown2:        data&64 == 64,
+		Unknown3:        data&128 == 128,
 	}
 }

--- a/d2common/d2fileformats/d2dt1/subtile_test.go
+++ b/d2common/d2fileformats/d2dt1/subtile_test.go
@@ -1,8 +1,9 @@
 package d2dt1
 
 import (
-	testify "github.com/stretchr/testify/assert"
 	"testing"
+
+	testify "github.com/stretchr/testify/assert"
 )
 
 func TestNewSubTile(t *testing.T) {

--- a/d2common/d2fileformats/d2pl2/pl2.go
+++ b/d2common/d2fileformats/d2pl2/pl2.go
@@ -7,45 +7,45 @@ import (
 )
 
 type PL2File struct {
-	BasePalette					PL2Palette
+	BasePalette PL2Palette
 
-	LightLevelVariations		[32]PL2PaletteTransform
-	InvColorVariations			[16]PL2PaletteTransform
-	SelectedUintShift			PL2PaletteTransform
-	AlphaBlend					[3][256]PL2PaletteTransform
-	AdditiveBlend				[256]PL2PaletteTransform
-	MultiplicativeBlend			[256]PL2PaletteTransform
-	HueVariations				[111]PL2PaletteTransform
-	RedTones					PL2PaletteTransform
-	GreenTones					PL2PaletteTransform
-	BlueTones					PL2PaletteTransform
-	UnknownVariations			[14]PL2PaletteTransform
-	MaxComponentBlend			[256]PL2PaletteTransform
-	DarkendColorShift			PL2PaletteTransform
+	LightLevelVariations [32]PL2PaletteTransform
+	InvColorVariations   [16]PL2PaletteTransform
+	SelectedUintShift    PL2PaletteTransform
+	AlphaBlend           [3][256]PL2PaletteTransform
+	AdditiveBlend        [256]PL2PaletteTransform
+	MultiplicativeBlend  [256]PL2PaletteTransform
+	HueVariations        [111]PL2PaletteTransform
+	RedTones             PL2PaletteTransform
+	GreenTones           PL2PaletteTransform
+	BlueTones            PL2PaletteTransform
+	UnknownVariations    [14]PL2PaletteTransform
+	MaxComponentBlend    [256]PL2PaletteTransform
+	DarkendColorShift    PL2PaletteTransform
 
-	TextColors					[13]PL2Color24Bits
-	TextColorShifts				[13]PL2PaletteTransform
+	TextColors      [13]PL2Color24Bits
+	TextColorShifts [13]PL2PaletteTransform
 }
 
 type PL2Color struct {
-	R	uint8
-	G	uint8
-	B	uint8
-	_	uint8
+	R uint8
+	G uint8
+	B uint8
+	_ uint8
 }
 
 type PL2Color24Bits struct {
-	R	uint8
-	G	uint8
-	B	uint8
+	R uint8
+	G uint8
+	B uint8
 }
 
 type PL2Palette struct {
-	Colors		[256]PL2Color
+	Colors [256]PL2Color
 }
 
 type PL2PaletteTransform struct {
-	Indices		[256]uint8
+	Indices [256]uint8
 }
 
 // uses restruct to read the binary dc6 data into structs
@@ -56,7 +56,7 @@ func LoadPL2(data []byte) (*PL2File, error) {
 
 	err := restruct.Unpack(data, binary.LittleEndian, &result)
 	if err != nil {
-	  return nil, err
+		return nil, err
 	}
 
 	return result, nil

--- a/d2common/stringutils.go
+++ b/d2common/stringutils.go
@@ -105,7 +105,7 @@ func SplitIntoLinesWithMaxWidth(fullSentence string, maxChars int) []string {
 	totalLength := 0
 	words := strings.Split(fullSentence, " ")
 	if len(words[0]) > maxChars {
-		// mostly happend within CJK characters (no whitespace)
+		// mostly happened within CJK characters (no whitespace)
 		return splitCjkIntoChunks(fullSentence, maxChars)
 	}
 	for _, word := range words {

--- a/d2core/d2asset/asset_manager.go
+++ b/d2core/d2asset/asset_manager.go
@@ -14,12 +14,12 @@ var (
 )
 
 type assetManager struct {
-	archiveManager			*archiveManager
-	fileManager				*fileManager
-	paletteManager			*paletteManager
-	paletteTransformManager	*paletteTransformManager
-	animationManager		*animationManager
-	fontManager				*fontManager
+	archiveManager          *archiveManager
+	fileManager             *fileManager
+	paletteManager          *paletteManager
+	paletteTransformManager *paletteTransformManager
+	animationManager        *animationManager
+	fontManager             *fontManager
 }
 
 func loadDC6(dc6Path string) (*d2dc6.DC6File, error) {

--- a/d2core/d2asset/d2asset.go
+++ b/d2core/d2asset/d2asset.go
@@ -7,9 +7,9 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dat"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2mpq"
 
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2pl2"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2config"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2term"
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2pl2"
 )
 
 var singleton *assetManager
@@ -18,13 +18,13 @@ func Initialize() error {
 	verifyNotInit()
 
 	var (
-		config					= d2config.Get()
-		archiveManager			= createArchiveManager(config)
-		fileManager				= createFileManager(config, archiveManager)
-		paletteManager			= createPaletteManager()
-		paletteTransformManager	= createPaletteTransformManager()
-		animationManager		= createAnimationManager()
-		fontManager				= createFontManager()
+		config                  = d2config.Get()
+		archiveManager          = createArchiveManager(config)
+		fileManager             = createFileManager(config, archiveManager)
+		paletteManager          = createPaletteManager()
+		paletteTransformManager = createPaletteTransformManager()
+		animationManager        = createAnimationManager()
+		fontManager             = createFontManager()
 	)
 
 	singleton = &assetManager{

--- a/d2core/d2asset/palette_transform_manager.go
+++ b/d2core/d2asset/palette_transform_manager.go
@@ -22,7 +22,7 @@ func (pm *paletteTransformManager) loadPaletteTransform(path string) (*d2pl2.PL2
 		return pl2.(*d2pl2.PL2File), nil
 	}
 
-	data, err := LoadFile(path); 
+	data, err := LoadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/d2core/d2map/engine.go
+++ b/d2core/d2map/engine.go
@@ -1,9 +1,10 @@
 package d2map
 
 import (
-	"github.com/beefsack/go-astar"
 	"math"
 	"strings"
+
+	"github.com/beefsack/go-astar"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 

--- a/d2core/d2map/hero.go
+++ b/d2core/d2map/hero.go
@@ -10,9 +10,9 @@ import (
 
 type Hero struct {
 	*AnimatedComposite
-	Equipment         d2inventory.CharacterEquipment
-	mode              d2enum.AnimationMode
-	direction         int
+	Equipment d2inventory.CharacterEquipment
+	mode      d2enum.AnimationMode
+	direction int
 }
 
 func CreateHero(x, y int, direction int, heroType d2enum.Hero, equipment d2inventory.CharacterEquipment) *Hero {

--- a/d2core/d2map/missile.go
+++ b/d2core/d2map/missile.go
@@ -2,10 +2,11 @@ package d2map
 
 import (
 	"fmt"
+	"math"
+
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2data/d2datadict"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
-	"math"
 )
 
 type Missile struct {

--- a/d2core/d2map/npc.go
+++ b/d2core/d2map/npc.go
@@ -1,11 +1,12 @@
 package d2map
 
 import (
+	"math/rand"
+
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2data/d2datadict"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
-	"math/rand"
 )
 
 type NPC struct {

--- a/d2core/d2map/range_searcher.go
+++ b/d2core/d2map/range_searcher.go
@@ -1,9 +1,10 @@
 package d2map
 
 import (
-	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 	"math"
 	"sort"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 )
 
 type MapEntitiesSearcher interface {

--- a/d2core/d2map/range_searcher_test.go
+++ b/d2core/d2map/range_searcher_test.go
@@ -1,10 +1,11 @@
 package d2map
 
 import (
+	"testing"
+
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2render"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type mockEntity struct {

--- a/d2core/d2render/filter.go
+++ b/d2core/d2render/filter.go
@@ -1,6 +1,6 @@
 package d2render
 
-// Filter represents the type of texture filter to be used when an image is maginified or minified.
+// Filter represents the type of texture filter to be used when an image is magnified or minified.
 type Filter int
 
 const (

--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -42,7 +42,7 @@ const (
 
 // ButtonLayout defines the type of buttons
 type ButtonLayout struct {
-	XSegments        int              //1
+	XSegments        int              // 1
 	YSegments        int              // 1
 	ResourceName     string           // Font Name
 	PaletteName      string           // PaletteType

--- a/d2game/d2player/inventory_grid_test.go
+++ b/d2game/d2player/inventory_grid_test.go
@@ -1,8 +1,9 @@
 package d2player
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type TestItem struct {


### PR DESCRIPTION
Typos located using misspell: https://github.com/client9/misspell

Formatting done using goimports: https://godoc.org/golang.org/x/tools/cmd/goimports