### PR TITLE
Migrate VSCode Golang extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
-        "ms-vscode.go",
+        "golang.go",
         "defaltd.go-coverage-viewer"
     ]
 }


### PR DESCRIPTION
The VSCode Golang extension, formally as `ms-vscode.go`, has now been moved over to the Golang org and is now at `golang.go`.