### PR TITLE
Fixes #360 Language dictionary crash

### DIFF
--- a/d2common/text_dictionary.go
+++ b/d2common/text_dictionary.go
@@ -19,7 +19,9 @@ var lookupTable map[string]string
 func TranslateString(key string) string {
 	result, ok := lookupTable[key]
 	if !ok {
-		log.Panicf("Could not find a string for the key '%s'", key)
+		// Fix to allow v.setDescLabels("#123") to be bypassed for a patch in issue #360. Reenable later.
+		// log.Panicf("Could not find a string for the key '%s'", key)
+		return key
 	}
 	return result
 }

--- a/d2game/d2gamescreen/character_select.go
+++ b/d2game/d2gamescreen/character_select.go
@@ -67,39 +67,39 @@ func (v *CharacterSelect) OnLoad() error {
 	v.background, _ = d2ui.LoadSprite(animation)
 	v.background.SetPosition(0, 0)
 
-	v.newCharButton = d2ui.CreateButton(d2ui.ButtonTypeTall, d2common.CombineStrings(dh.SplitIntoLinesWithMaxWidth(d2common.TranslateString("#831"), 15)))
+	v.newCharButton = d2ui.CreateButton(d2ui.ButtonTypeTall, d2common.CombineStrings(dh.SplitIntoLinesWithMaxWidth("CREATE NEW CHARACTER", 15)))
 	v.newCharButton.SetPosition(33, 468)
 	v.newCharButton.OnActivated(func() { v.onNewCharButtonClicked() })
 	d2ui.AddWidget(&v.newCharButton)
 
-	v.convertCharButton = d2ui.CreateButton(d2ui.ButtonTypeTall, d2common.CombineStrings(dh.SplitIntoLinesWithMaxWidth(d2common.TranslateString("#825"), 15)))
+	v.convertCharButton = d2ui.CreateButton(d2ui.ButtonTypeTall, d2common.CombineStrings(dh.SplitIntoLinesWithMaxWidth("CONVERT TO EXPANSION", 15)))
 	v.convertCharButton.SetPosition(233, 468)
 	v.convertCharButton.SetEnabled(false)
 	d2ui.AddWidget(&v.convertCharButton)
 
-	v.deleteCharButton = d2ui.CreateButton(d2ui.ButtonTypeTall, d2common.CombineStrings(dh.SplitIntoLinesWithMaxWidth(d2common.TranslateString("#832"), 15)))
+	v.deleteCharButton = d2ui.CreateButton(d2ui.ButtonTypeTall, d2common.CombineStrings(dh.SplitIntoLinesWithMaxWidth("DELETE CHARACTER", 15)))
 	v.deleteCharButton.OnActivated(func() { v.onDeleteCharButtonClicked() })
 	v.deleteCharButton.SetPosition(433, 468)
 	d2ui.AddWidget(&v.deleteCharButton)
 
-	v.exitButton = d2ui.CreateButton(d2ui.ButtonTypeMedium, d2common.TranslateString("#970"))
+	v.exitButton = d2ui.CreateButton(d2ui.ButtonTypeMedium, "EXIT")
 	v.exitButton.SetPosition(33, 537)
 	v.exitButton.OnActivated(func() { v.onExitButtonClicked() })
 	d2ui.AddWidget(&v.exitButton)
 
-	v.deleteCharCancelButton = d2ui.CreateButton(d2ui.ButtonTypeOkCancel, d2common.TranslateString("#4231"))
+	v.deleteCharCancelButton = d2ui.CreateButton(d2ui.ButtonTypeOkCancel, "NO")
 	v.deleteCharCancelButton.SetPosition(282, 308)
 	v.deleteCharCancelButton.SetVisible(false)
 	v.deleteCharCancelButton.OnActivated(func() { v.onDeleteCharacterCancelClicked() })
 	d2ui.AddWidget(&v.deleteCharCancelButton)
 
-	v.deleteCharOkButton = d2ui.CreateButton(d2ui.ButtonTypeOkCancel, d2common.TranslateString("#4227"))
+	v.deleteCharOkButton = d2ui.CreateButton(d2ui.ButtonTypeOkCancel, "YES")
 	v.deleteCharOkButton.SetPosition(422, 308)
 	v.deleteCharOkButton.SetVisible(false)
 	v.deleteCharOkButton.OnActivated(func() { v.onDeleteCharacterConfirmClicked() })
 	d2ui.AddWidget(&v.deleteCharOkButton)
 
-	v.okButton = d2ui.CreateButton(d2ui.ButtonTypeMedium, d2common.TranslateString("#971"))
+	v.okButton = d2ui.CreateButton(d2ui.ButtonTypeMedium, "OK")
 	v.okButton.SetPosition(625, 537)
 	v.okButton.OnActivated(func() { v.onOkButtonClicked() })
 	d2ui.AddWidget(&v.okButton)
@@ -109,7 +109,7 @@ func (v *CharacterSelect) OnLoad() error {
 	v.d2HeroTitle.Alignment = d2ui.LabelAlignCenter
 
 	v.deleteCharConfirmLabel = d2ui.CreateLabel(d2resource.Font16, d2resource.PaletteUnits)
-	lines := dh.SplitIntoLinesWithMaxWidth(d2common.TranslateString("#1878"), 29)
+	lines := dh.SplitIntoLinesWithMaxWidth("Are you sure that you want to delete this character? Take note: this will delete all versions of this Character.", 29)
 	v.deleteCharConfirmLabel.SetText(strings.Join(lines, "\n"))
 	v.deleteCharConfirmLabel.Alignment = d2ui.LabelAlignCenter
 	v.deleteCharConfirmLabel.SetPosition(400, 185)
@@ -151,7 +151,7 @@ func (v *CharacterSelect) onScrollUpdate() {
 }
 
 func (v *CharacterSelect) updateCharacterBoxes() {
-	expText := d2common.TranslateString("#803")
+	expText := "EXPANSION CHARACTER"
 	for i := 0; i < 8; i++ {
 		idx := i + (v.charScrollbar.GetCurrentOffset() * 2)
 		if idx >= len(v.gameStates) {

--- a/d2game/d2gamescreen/credits.go
+++ b/d2game/d2gamescreen/credits.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 	dh "github.com/OpenDiablo2/OpenDiablo2/d2common"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
 
@@ -70,7 +69,7 @@ func (v *Credits) OnLoad() error {
 	v.creditsBackground, _ = d2ui.LoadSprite(animation)
 	v.creditsBackground.SetPosition(0, 0)
 
-	v.exitButton = d2ui.CreateButton(d2ui.ButtonTypeMedium, d2common.TranslateString("#970"))
+	v.exitButton = d2ui.CreateButton(d2ui.ButtonTypeMedium, "EXIT")
 	v.exitButton.SetPosition(33, 543)
 	v.exitButton.OnActivated(func() { v.onExitButtonClicked() })
 	d2ui.AddWidget(&v.exitButton)

--- a/d2game/d2gamescreen/main_menu.go
+++ b/d2game/d2gamescreen/main_menu.go
@@ -101,7 +101,7 @@ func (v *MainMenu) OnLoad() error {
 
 	v.copyrightLabel2 = d2ui.CreateLabel(d2resource.FontFormal12, d2resource.PaletteStatic)
 	v.copyrightLabel2.Alignment = d2ui.LabelAlignCenter
-	v.copyrightLabel2.SetText(d2common.TranslateString("#1614"))
+	v.copyrightLabel2.SetText("All Rights Reserved.")
 	v.copyrightLabel2.Color = color.RGBA{R: 188, G: 168, B: 140, A: 255}
 	v.copyrightLabel2.SetPosition(400, 525)
 
@@ -143,21 +143,21 @@ func (v *MainMenu) OnLoad() error {
 	v.diabloLogoRightBack, _ = d2ui.LoadSprite(animation)
 	v.diabloLogoRightBack.SetPosition(400, 120)
 
-	v.exitDiabloButton = d2ui.CreateButton(d2ui.ButtonTypeWide, d2common.TranslateString("#1625"))
+	v.exitDiabloButton = d2ui.CreateButton(d2ui.ButtonTypeWide, "EXIT DIABLO II")
 	v.exitDiabloButton.SetPosition(264, 535)
 	v.exitDiabloButton.OnActivated(func() { v.onExitButtonClicked() })
 	d2ui.AddWidget(&v.exitDiabloButton)
 
-	v.creditsButton = d2ui.CreateButton(d2ui.ButtonTypeShort, d2common.TranslateString("#1627"))
+	v.creditsButton = d2ui.CreateButton(d2ui.ButtonTypeShort, "CREDITS")
 	v.creditsButton.SetPosition(264, 505)
 	v.creditsButton.OnActivated(func() { v.onCreditsButtonClicked() })
 	d2ui.AddWidget(&v.creditsButton)
 
-	v.cinematicsButton = d2ui.CreateButton(d2ui.ButtonTypeShort, d2common.TranslateString("#1639"))
+	v.cinematicsButton = d2ui.CreateButton(d2ui.ButtonTypeShort, "CINEMATICS")
 	v.cinematicsButton.SetPosition(401, 505)
 	d2ui.AddWidget(&v.cinematicsButton)
 
-	v.singlePlayerButton = d2ui.CreateButton(d2ui.ButtonTypeWide, d2common.TranslateString("#1620"))
+	v.singlePlayerButton = d2ui.CreateButton(d2ui.ButtonTypeWide, "SINGLE PLAYER")
 	v.singlePlayerButton.SetPosition(264, 290)
 	v.singlePlayerButton.OnActivated(func() { v.onSinglePlayerClicked() })
 	d2ui.AddWidget(&v.singlePlayerButton)
@@ -177,7 +177,7 @@ func (v *MainMenu) OnLoad() error {
 	v.mapTestButton.OnActivated(func() { v.onMapTestClicked() })
 	d2ui.AddWidget(&v.mapTestButton)
 
-	v.networkTcpIpButton = d2ui.CreateButton(d2ui.ButtonTypeWide, d2common.TranslateString("#1666"))
+	v.networkTcpIpButton = d2ui.CreateButton(d2ui.ButtonTypeWide, "TCP/IP GAME")
 	v.networkTcpIpButton.SetPosition(264, 280)
 	v.networkTcpIpButton.OnActivated(func() { v.onNetworkTcpIpClicked() })
 	d2ui.AddWidget(&v.networkTcpIpButton)
@@ -192,12 +192,12 @@ func (v *MainMenu) OnLoad() error {
 	v.btnTcpIpCancel.OnActivated(func() { v.onTcpIpCancelClicked() })
 	d2ui.AddWidget(&v.btnTcpIpCancel)
 
-	v.btnTcpIpHostGame = d2ui.CreateButton(d2ui.ButtonTypeWide, d2common.TranslateString("#1675"))
+	v.btnTcpIpHostGame = d2ui.CreateButton(d2ui.ButtonTypeWide, "HOST GAME")
 	v.btnTcpIpHostGame.SetPosition(264, 280)
 	v.btnTcpIpHostGame.OnActivated(func() { v.onTcpIpHostGameClicked() })
 	d2ui.AddWidget(&v.btnTcpIpHostGame)
 
-	v.btnTcpIpJoinGame = d2ui.CreateButton(d2ui.ButtonTypeWide, d2common.TranslateString("#1676"))
+	v.btnTcpIpJoinGame = d2ui.CreateButton(d2ui.ButtonTypeWide, "JOIN GAME")
 	v.btnTcpIpJoinGame.SetPosition(264, 320)
 	v.btnTcpIpJoinGame.OnActivated(func() { v.onTcpIpJoinGameClicked() })
 	d2ui.AddWidget(&v.btnTcpIpJoinGame)
@@ -205,7 +205,7 @@ func (v *MainMenu) OnLoad() error {
 	v.tcpIpOptionsLabel = d2ui.CreateLabel(d2resource.Font42, d2resource.PaletteUnits)
 	v.tcpIpOptionsLabel.SetPosition(400, 23)
 	v.tcpIpOptionsLabel.Alignment = d2ui.LabelAlignCenter
-	v.tcpIpOptionsLabel.SetText(d2common.TranslateString("#1667"))
+	v.tcpIpOptionsLabel.SetText("TCP/IP Options")
 
 	animation, _ = d2asset.LoadAnimation(d2resource.PopUpOkCancel, d2resource.PaletteFechar)
 	v.serverIpBackground, _ = d2ui.LoadSprite(animation)
@@ -214,7 +214,7 @@ func (v *MainMenu) OnLoad() error {
 	v.tcpJoinGameLabel = d2ui.CreateLabel(d2resource.Font16, d2resource.PaletteUnits)
 	v.tcpJoinGameLabel.Alignment = d2ui.LabelAlignCenter
 	v.tcpJoinGameLabel.SetText(d2common.CombineStrings(d2common.
-		SplitIntoLinesWithMaxWidth(d2common.TranslateString("#327"), 23)))
+		SplitIntoLinesWithMaxWidth("Enter Host IP Address to Join Game", 23)))
 	v.tcpJoinGameLabel.Color = color.RGBA{R: 216, G: 196, B: 128, A: 255}
 	v.tcpJoinGameLabel.SetPosition(400, 190)
 
@@ -223,12 +223,12 @@ func (v *MainMenu) OnLoad() error {
 	v.tcpJoinGameEntry.SetFilter("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890._:")
 	d2ui.AddWidget(&v.tcpJoinGameEntry)
 
-	v.btnServerIpCancel = d2ui.CreateButton(d2ui.ButtonTypeOkCancel, d2common.TranslateString("#1612"))
+	v.btnServerIpCancel = d2ui.CreateButton(d2ui.ButtonTypeOkCancel, "CANCEL")
 	v.btnServerIpCancel.SetPosition(285, 305)
 	v.btnServerIpCancel.OnActivated(func() { v.onBtnTcpIpCancelClicked() })
 	d2ui.AddWidget(&v.btnServerIpCancel)
 
-	v.btnServerIpOk = d2ui.CreateButton(d2ui.ButtonTypeOkCancel, d2common.TranslateString("#971"))
+	v.btnServerIpOk = d2ui.CreateButton(d2ui.ButtonTypeOkCancel, "OK")
 	v.btnServerIpOk.SetPosition(420, 305)
 	v.btnServerIpOk.OnActivated(func() { v.onBtnTcpIpOkClicked() })
 	d2ui.AddWidget(&v.btnServerIpOk)

--- a/d2game/d2gamescreen/select_hero_class.go
+++ b/d2game/d2gamescreen/select_hero_class.go
@@ -112,12 +112,12 @@ func (v *SelectHeroClass) OnLoad() error {
 	v.campfire.PlayForward()
 	v.campfire.SetBlend(true)
 
-	v.exitButton = d2ui.CreateButton(d2ui.ButtonTypeMedium, d2common.TranslateString("#970"))
+	v.exitButton = d2ui.CreateButton(d2ui.ButtonTypeMedium, "EXIT")
 	v.exitButton.SetPosition(33, 537)
 	v.exitButton.OnActivated(func() { v.onExitButtonClicked() })
 	d2ui.AddWidget(&v.exitButton)
 
-	v.okButton = d2ui.CreateButton(d2ui.ButtonTypeMedium, d2common.TranslateString("#971"))
+	v.okButton = d2ui.CreateButton(d2ui.ButtonTypeMedium, "OK")
 	v.okButton.SetPosition(630, 537)
 	v.okButton.OnActivated(func() { v.onOkButtonClicked() })
 	v.okButton.SetVisible(false)
@@ -127,7 +127,7 @@ func (v *SelectHeroClass) OnLoad() error {
 	v.heroNameLabel = d2ui.CreateLabel(d2resource.Font16, d2resource.PaletteUnits)
 	v.heroNameLabel.Alignment = d2ui.LabelAlignLeft
 	v.heroNameLabel.Color = color.RGBA{R: 216, G: 196, B: 128, A: 255}
-	v.heroNameLabel.SetText(d2common.TranslateString("#1694"))
+	v.heroNameLabel.SetText("Character Name")
 	v.heroNameLabel.SetPosition(321, 475)
 
 	v.heroNameTextbox = d2ui.CreateTextbox()
@@ -143,7 +143,7 @@ func (v *SelectHeroClass) OnLoad() error {
 	v.expansionCharLabel = d2ui.CreateLabel(d2resource.Font16, d2resource.PaletteUnits)
 	v.expansionCharLabel.Alignment = d2ui.LabelAlignLeft
 	v.expansionCharLabel.Color = color.RGBA{R: 216, G: 196, B: 128, A: 255}
-	v.expansionCharLabel.SetText(d2common.TranslateString("#803"))
+	v.expansionCharLabel.SetText("EXPANSION CHARACTER")
 	v.expansionCharLabel.SetPosition(339, 526)
 
 	v.hardcoreCheckbox = d2ui.CreateCheckbox(false)
@@ -154,7 +154,7 @@ func (v *SelectHeroClass) OnLoad() error {
 	v.hardcoreCharLabel = d2ui.CreateLabel(d2resource.Font16, d2resource.PaletteUnits)
 	v.hardcoreCharLabel.Alignment = d2ui.LabelAlignLeft
 	v.hardcoreCharLabel.Color = color.RGBA{R: 216, G: 196, B: 128, A: 255}
-	v.hardcoreCharLabel.SetText(d2common.TranslateString("#1696"))
+	v.hardcoreCharLabel.SetText("Hardcore")
 	v.hardcoreCharLabel.SetPosition(339, 548)
 
 	v.heroRenderInfo[d2enum.HeroBarbarian] = &HeroRenderInfo{
@@ -575,30 +575,31 @@ func (v *SelectHeroClass) renderHero(screen d2render.Surface, hero d2enum.Hero) 
 }
 
 func (v *SelectHeroClass) updateHeroText() {
+	// v.setDescLabels("") really takes a string translation key, but temporarily disabled.
 	switch v.selectedHero {
 	case d2enum.HeroNone:
 		return
 	case d2enum.HeroBarbarian:
 		v.heroClassLabel.SetText(d2common.TranslateString("partycharbar"))
-		v.setDescLabels("#1709")
+		v.setDescLabels("He is unequaled in close-quarters combat and mastery of weapons.")
 	case d2enum.HeroNecromancer:
 		v.heroClassLabel.SetText(d2common.TranslateString("partycharnec"))
-		v.setDescLabels("#1704")
+		v.setDescLabels("Summoning undead minions and cursing his enemies are his specialties.")
 	case d2enum.HeroPaladin:
 		v.heroClassLabel.SetText(d2common.TranslateString("partycharpal"))
-		v.setDescLabels("#1711")
+		v.setDescLabels("He is a natural party leader, holy man, and blessed warrior.")
 	case d2enum.HeroAssassin:
 		v.heroClassLabel.SetText(d2common.TranslateString("partycharass"))
-		v.setDescLabels("#305")
+		v.setDescLabels("Schooled in the Martial Arts, her mind and body are deadly weapons.")
 	case d2enum.HeroSorceress:
 		v.heroClassLabel.SetText(d2common.TranslateString("partycharsor"))
-		v.setDescLabels("#1710")
+		v.setDescLabels("She has mastered the elemental magicks -- fire, lightning, and ice.")
 	case d2enum.HeroAmazon:
 		v.heroClassLabel.SetText(d2common.TranslateString("partycharama"))
-		v.setDescLabels("#1698")
+		v.setDescLabels("Skilled with the spear and the bow, she is a very versatile fighter.")
 	case d2enum.HeroDruid:
 		v.heroClassLabel.SetText(d2common.TranslateString("partychardru"))
-		v.setDescLabels("#304")
+		v.setDescLabels("Commanding the forces of nature, he summons wild beasts and raging storms to his side.")
 	}
 	/*
 	   if (selectedHero == null)


### PR DESCRIPTION
Crashes were due to missing translation. This PR temporarily replaces the translateString calls for the default string directly.

in `select_hero_class.go` there is a level of indirection before the call to translateString, and for this reason, its `panic` call got temporarily diverted.