### PR TITLE
camera offset for ui panels :

### DIFF
--- a/d2core/d2map/renderer.go
+++ b/d2core/d2map/renderer.go
@@ -58,3 +58,15 @@ func (m *MapRenderer) ScreenToOrtho(x, y int) (float64, float64) {
 func (m *MapRenderer) WorldToOrtho(x, y float64) (float64, float64) {
 	return m.viewport.WorldToOrtho(x, y)
 }
+
+func (m *MapRenderer) ViewportToLeft() {
+	m.viewport.toLeft()
+}
+
+func (m *MapRenderer) ViewportToRight() {
+	m.viewport.toRight()
+}
+
+func (m *MapRenderer) ViewportDefault() {
+	m.viewport.resetAlign()
+}

--- a/d2core/d2map/viewport.go
+++ b/d2core/d2map/viewport.go
@@ -23,6 +23,7 @@ type Viewport struct {
 	transStack        []worldTrans
 	transCurrent      worldTrans
 	camera            *Camera
+	align             int
 }
 
 func NewViewport(x, y, width, height int) *Viewport {
@@ -97,7 +98,7 @@ func (v *Viewport) IsTileRectVisible(rect d2common.Rectangle) bool {
 func (v *Viewport) IsOrthoRectVisible(x1, y1, x2, y2 float64) bool {
 	screenX1, screenY1 := v.OrthoToScreen(x1, y1)
 	screenX2, screenY2 := v.OrthoToScreen(x2, y2)
-	return !(screenX1 >= v.defaultScreenRect.Width || screenX2 < 0 || screenY1 >= v.defaultScreenRect.Height || screenY2 < 0)
+	return !(screenX1 >= v.screenRect.Width || screenX2 < 0 || screenY1 >= v.screenRect.Height || screenY2 < 0)
 }
 
 func (v *Viewport) GetTranslationOrtho() (float64, float64) {
@@ -145,15 +146,24 @@ func (v *Viewport) getCameraOffset() (float64, float64) {
 }
 
 func (v *Viewport) toLeft() {
+	if v.align == left {
+		return
+	}
 	v.screenRect.Width = v.defaultScreenRect.Width / 2
 }
 
 func (v *Viewport) toRight() {
+	if v.align == right {
+		return
+	}
 	v.screenRect.Width = v.defaultScreenRect.Width / 2
 	v.screenRect.Left = v.defaultScreenRect.Left + v.defaultScreenRect.Width/2
 }
 
 func (v *Viewport) resetAlign() {
+	if v.align == center {
+		return
+	}
 	v.screenRect.Width = v.defaultScreenRect.Width
 	v.screenRect.Left = v.defaultScreenRect.Left
 }

--- a/d2core/d2map/viewport.go
+++ b/d2core/d2map/viewport.go
@@ -11,16 +11,29 @@ type worldTrans struct {
 	y float64
 }
 
+const (
+	center = 0
+	left   = 1
+	right  = 2
+)
+
 type Viewport struct {
-	screenRect   d2common.Rectangle
-	transStack   []worldTrans
-	transCurrent worldTrans
-	camera       *Camera
+	defaultScreenRect d2common.Rectangle
+	screenRect        d2common.Rectangle
+	transStack        []worldTrans
+	transCurrent      worldTrans
+	camera            *Camera
 }
 
 func NewViewport(x, y, width, height int) *Viewport {
 	return &Viewport{
 		screenRect: d2common.Rectangle{
+			Left:   x,
+			Top:    y,
+			Width:  width,
+			Height: height,
+		},
+		defaultScreenRect: d2common.Rectangle{
 			Left:   x,
 			Top:    y,
 			Width:  width,
@@ -84,7 +97,7 @@ func (v *Viewport) IsTileRectVisible(rect d2common.Rectangle) bool {
 func (v *Viewport) IsOrthoRectVisible(x1, y1, x2, y2 float64) bool {
 	screenX1, screenY1 := v.OrthoToScreen(x1, y1)
 	screenX2, screenY2 := v.OrthoToScreen(x2, y2)
-	return !(screenX1 >= v.screenRect.Width || screenX2 < 0 || screenY1 >= v.screenRect.Height || screenY2 < 0)
+	return !(screenX1 >= v.defaultScreenRect.Width || screenX2 < 0 || screenY1 >= v.defaultScreenRect.Height || screenY2 < 0)
 }
 
 func (v *Viewport) GetTranslationOrtho() (float64, float64) {
@@ -129,4 +142,18 @@ func (v *Viewport) getCameraOffset() (float64, float64) {
 	camY -= float64(v.screenRect.Height / 2)
 
 	return camX, camY
+}
+
+func (v *Viewport) toLeft() {
+	v.screenRect.Width = v.defaultScreenRect.Width / 2
+}
+
+func (v *Viewport) toRight() {
+	v.screenRect.Width = v.defaultScreenRect.Width / 2
+	v.screenRect.Left = v.defaultScreenRect.Left + v.defaultScreenRect.Width/2
+}
+
+func (v *Viewport) resetAlign() {
+	v.screenRect.Width = v.defaultScreenRect.Width
+	v.screenRect.Left = v.defaultScreenRect.Left
 }

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -55,14 +55,33 @@ func NewGameControls(hero *d2map.Player, mapEngine *d2map.MapEngine, mapRenderer
 func (g *GameControls) OnKeyDown(event d2input.KeyEvent) bool {
 	if event.Key == d2input.KeyI {
 		g.inventory.Toggle()
+		g.updateLayout()
 		return true
 	}
 	if event.Key == d2input.KeyC {
 		g.heroStats.Toggle()
+		g.updateLayout()
 		return true
 	}
 
 	return false
+}
+
+func (g *GameControls) updateLayout() {
+	isRightPanelOpen := false
+	isLeftPanelOpen := false
+
+	// todo : add same logic when adding quest log and skill tree
+	isRightPanelOpen = g.inventory.isOpen || isRightPanelOpen
+	isLeftPanelOpen = g.heroStats.isOpen || isLeftPanelOpen
+
+	if isRightPanelOpen == isLeftPanelOpen {
+		g.mapRenderer.ViewportDefault()
+	} else if isRightPanelOpen == true {
+		g.mapRenderer.ViewportToLeft()
+	} else {
+		g.mapRenderer.ViewportToRight()
+	}
 }
 
 func (g *GameControls) OnMouseButtonDown(event d2input.MouseEvent) bool {


### PR DESCRIPTION
closes #358 

added maprenderer viewport to be aligned left or right

calling alignement on keyPress in game_controls


I'm unsure of the change inside isOrthoRectVisible. Without this change, the viewport aligned on right would look like this : 
![image](https://user-images.githubusercontent.com/29370205/85232997-c0c10c00-b403-11ea-8404-79f2dab977f6.png)

If you see room for improvements, let me know
