### PR TITLE
Escape menu - Keyboard support and minor improvements

### DIFF
--- a/d2common/d2resource/resource_paths.go
+++ b/d2common/d2resource/resource_paths.go
@@ -253,6 +253,7 @@ const (
 
 	// --- Sound Effects ---
 
+	SFXCursorSelect        = "cursor_select"
 	SFXButtonClick         = "cursor_button_click"
 	SFXAmazonDeselect      = "cursor_amazon_deselect"
 	SFXAmazonSelect        = "cursor_amazon_select"

--- a/d2game/d2player/escape_menu.go
+++ b/d2game/d2player/escape_menu.go
@@ -29,12 +29,11 @@ const (
 
 // EscapeMenu is the overlay menu shown in-game when pressing Escape
 type EscapeMenu struct {
-	current   EscapeOption
-	isOpen    bool
-	labels    []d2ui.Label
-	pentLeft  *d2ui.Sprite
-	pentRight *d2ui.Sprite
-
+	current     EscapeOption
+	isOpen      bool
+	labels      []d2ui.Label
+	pentLeft    *d2ui.Sprite
+	pentRight   *d2ui.Sprite
 	selectSound d2audio.SoundEffect
 
 	// pre-computations

--- a/d2game/d2player/escape_menu.go
+++ b/d2game/d2player/escape_menu.go
@@ -131,7 +131,45 @@ func (m *EscapeMenu) IsOpen() bool {
 }
 
 func (m *EscapeMenu) Toggle() {
+	m.reset()
 	m.isOpen = !m.isOpen
+}
+
+func (m *EscapeMenu) reset() {
+	m.current = EscapeOptions
+}
+
+func (m *EscapeMenu) OnUpKey() {
+	switch m.current {
+	case EscapeSaveExit:
+		m.current = EscapeOptions
+	case EscapeReturn:
+		m.current = EscapeSaveExit
+	}
+}
+
+func (m *EscapeMenu) OnDownKey() {
+	switch m.current {
+	case EscapeOptions:
+		m.current = EscapeSaveExit
+	case EscapeSaveExit:
+		m.current = EscapeReturn
+	}
+}
+
+func (m *EscapeMenu) OnEnterKey() {
+	m.triggerCurrentSelection()
+}
+
+func (m *EscapeMenu) triggerCurrentSelection() {
+	switch m.current {
+	case EscapeOptions:
+		m.onOptions()
+	case EscapeSaveExit:
+		m.onSaveAndExit()
+	case EscapeReturn:
+		m.onReturnToGame()
+	}
 }
 
 func (m *EscapeMenu) Open() {
@@ -170,19 +208,22 @@ func (m *EscapeMenu) OnMouseButtonDown(event d2input.MouseEvent) bool {
 
 	lbl := &m.labels[EscapeOptions]
 	if m.toMouseRegion(event.HandlerEvent, lbl) == regIn {
-		m.onOptions()
+		m.current = EscapeOptions
+		m.triggerCurrentSelection()
 		return false
 	}
 
 	lbl = &m.labels[EscapeSaveExit]
 	if m.toMouseRegion(event.HandlerEvent, lbl) == regIn {
-		m.onSaveAndExit()
+		m.current = EscapeSaveExit
+		m.triggerCurrentSelection()
 		return false
 	}
 
 	lbl = &m.labels[EscapeReturn]
 	if m.toMouseRegion(event.HandlerEvent, lbl) == regIn {
-		m.onReturnToGame()
+		m.current = EscapeReturn
+		m.triggerCurrentSelection()
 		return false
 	}
 

--- a/d2game/d2player/escape_menu.go
+++ b/d2game/d2player/escape_menu.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2audio"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2input"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2render"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2ui"
@@ -34,6 +35,8 @@ type EscapeMenu struct {
 	pentLeft  *d2ui.Sprite
 	pentRight *d2ui.Sprite
 
+	selectSound d2audio.SoundEffect
+
 	// pre-computations
 	pentWidth  int
 	pentHeight int
@@ -49,7 +52,6 @@ func NewEscapeMenu() *EscapeMenu {
 
 // ScreenLoadHandler
 func (m *EscapeMenu) OnLoad() error {
-
 	m.labels = []d2ui.Label{
 		d2ui.CreateLabel(d2resource.Font42, d2resource.PaletteSky),
 		d2ui.CreateLabel(d2resource.Font42, d2resource.PaletteSky),
@@ -75,6 +77,8 @@ func (m *EscapeMenu) OnLoad() error {
 
 	m.pentWidth, m.pentHeight = m.pentLeft.GetFrameBounds()
 	_, m.textHeight = m.labels[EscapeOptions].GetSize()
+
+	m.selectSound, _ = d2audio.LoadSoundEffect(d2resource.SFXCursorSelect)
 
 	return nil
 }
@@ -158,17 +162,20 @@ func (m *EscapeMenu) OnDownKey() {
 }
 
 func (m *EscapeMenu) OnEnterKey() {
-	m.triggerCurrentSelection()
+	m.selectCurrent()
 }
 
-func (m *EscapeMenu) triggerCurrentSelection() {
+func (m *EscapeMenu) selectCurrent() {
 	switch m.current {
 	case EscapeOptions:
 		m.onOptions()
+		m.selectSound.Play()
 	case EscapeSaveExit:
 		m.onSaveAndExit()
+		m.selectSound.Play()
 	case EscapeReturn:
 		m.onReturnToGame()
+		m.selectSound.Play()
 	}
 }
 
@@ -209,21 +216,21 @@ func (m *EscapeMenu) OnMouseButtonDown(event d2input.MouseEvent) bool {
 	lbl := &m.labels[EscapeOptions]
 	if m.toMouseRegion(event.HandlerEvent, lbl) == regIn {
 		m.current = EscapeOptions
-		m.triggerCurrentSelection()
+		m.selectCurrent()
 		return false
 	}
 
 	lbl = &m.labels[EscapeSaveExit]
 	if m.toMouseRegion(event.HandlerEvent, lbl) == regIn {
 		m.current = EscapeSaveExit
-		m.triggerCurrentSelection()
+		m.selectCurrent()
 		return false
 	}
 
 	lbl = &m.labels[EscapeReturn]
 	if m.toMouseRegion(event.HandlerEvent, lbl) == regIn {
 		m.current = EscapeReturn
-		m.triggerCurrentSelection()
+		m.selectCurrent()
 		return false
 	}
 

--- a/d2game/d2player/escape_menu.go
+++ b/d2game/d2player/escape_menu.go
@@ -83,11 +83,6 @@ func (m *EscapeMenu) OnLoad() error {
 	return nil
 }
 
-// ScreenUnloadHandler
-func (m *EscapeMenu) OnUnload() error {
-	return nil
-}
-
 // ScreenRenderHandler
 func (m *EscapeMenu) Render(target d2render.Surface) error {
 	if !m.isOpen {
@@ -135,7 +130,9 @@ func (m *EscapeMenu) IsOpen() bool {
 }
 
 func (m *EscapeMenu) Toggle() {
-	m.reset()
+	if !m.isOpen {
+		m.reset()
+	}
 	m.isOpen = !m.isOpen
 }
 
@@ -163,28 +160,6 @@ func (m *EscapeMenu) OnDownKey() {
 
 func (m *EscapeMenu) OnEnterKey() {
 	m.selectCurrent()
-}
-
-func (m *EscapeMenu) selectCurrent() {
-	switch m.current {
-	case EscapeOptions:
-		m.onOptions()
-		m.selectSound.Play()
-	case EscapeSaveExit:
-		m.onSaveAndExit()
-		m.selectSound.Play()
-	case EscapeReturn:
-		m.onReturnToGame()
-		m.selectSound.Play()
-	}
-}
-
-func (m *EscapeMenu) Open() {
-	m.isOpen = true
-}
-
-func (m *EscapeMenu) Close() {
-	m.isOpen = false
 }
 
 // Moves current selection marker to closes option to mouse.
@@ -235,6 +210,20 @@ func (m *EscapeMenu) OnMouseButtonDown(event d2input.MouseEvent) bool {
 	}
 
 	return false
+}
+
+func (m *EscapeMenu) selectCurrent() {
+	switch m.current {
+	case EscapeOptions:
+		m.onOptions()
+		m.selectSound.Play()
+	case EscapeSaveExit:
+		m.onSaveAndExit()
+		m.selectSound.Play()
+	case EscapeReturn:
+		m.onReturnToGame()
+		m.selectSound.Play()
+	}
 }
 
 // User clicked on "OPTIONS"

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -59,12 +59,12 @@ func (g *GameControls) OnKeyDown(event d2input.KeyEvent) bool {
 		g.escapeMenu.Toggle()
 		return true
 	}
-	if event.Key == d2input.KeyDown {
-		g.escapeMenu.OnDownKey()
-		return true
-	}
 	if event.Key == d2input.KeyUp {
 		g.escapeMenu.OnUpKey()
+		return true
+	}
+	if event.Key == d2input.KeyDown {
+		g.escapeMenu.OnDownKey()
 		return true
 	}
 	if event.Key == d2input.KeyEnter {

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -55,32 +55,24 @@ func NewGameControls(hero *d2map.Player, mapEngine *d2map.MapEngine, mapRenderer
 }
 
 func (g *GameControls) OnKeyDown(event d2input.KeyEvent) bool {
-	if event.Key == d2input.KeyEscape {
+	switch event.Key {
+	case d2input.KeyEscape:
 		g.escapeMenu.Toggle()
-		return true
-	}
-	if event.Key == d2input.KeyUp {
+	case d2input.KeyUp:
 		g.escapeMenu.OnUpKey()
-		return true
-	}
-	if event.Key == d2input.KeyDown {
+	case d2input.KeyDown:
 		g.escapeMenu.OnDownKey()
-		return true
-	}
-	if event.Key == d2input.KeyEnter {
+	case d2input.KeyEnter:
 		g.escapeMenu.OnEnterKey()
-		return true
-	}
-	if event.Key == d2input.KeyI {
+	case d2input.KeyI:
 		g.inventory.Toggle()
-		return true
-	}
-	if event.Key == d2input.KeyC {
+	case d2input.KeyC:
 		g.heroStats.Toggle()
-		return true
+	default:
+		return false
 	}
 
-	return false
+	return true
 }
 
 func (g *GameControls) OnMouseMove(event d2input.MouseMoveEvent) bool {

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -57,6 +57,11 @@ func NewGameControls(hero *d2map.Player, mapEngine *d2map.MapEngine, mapRenderer
 func (g *GameControls) OnKeyDown(event d2input.KeyEvent) bool {
 	switch event.Key {
 	case d2input.KeyEscape:
+		if g.inventory.IsOpen() || g.heroStats.IsOpen() {
+			g.inventory.Close()
+			g.heroStats.Close()
+			break
+		}
 		g.escapeMenu.Toggle()
 	case d2input.KeyUp:
 		g.escapeMenu.OnUpKey()

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -59,6 +59,18 @@ func (g *GameControls) OnKeyDown(event d2input.KeyEvent) bool {
 		g.escapeMenu.Toggle()
 		return true
 	}
+	if event.Key == d2input.KeyDown {
+		g.escapeMenu.OnDownKey()
+		return true
+	}
+	if event.Key == d2input.KeyUp {
+		g.escapeMenu.OnUpKey()
+		return true
+	}
+	if event.Key == d2input.KeyEnter {
+		g.escapeMenu.OnEnterKey()
+		return true
+	}
 	if event.Key == d2input.KeyI {
 		g.inventory.Toggle()
 		return true


### PR DESCRIPTION
Hi, this is my first PR on the project so please don't hesitate to let me know if I broke the structure/design/whatever.

It partially fixes #353 (see comments there).

Work done:
* Add support for up/down/enter keys in the ingame "escape menu"
* Add sound when selecting an item
* Reset the menu when toggling it
* Prevent opening the menu over the inventory or hero stats panels
* I also took the liberty to remove some methods that were not part of an interface and were not used, so as to avoid confusion or unintended side effects (YAGNI)