### PR TITLE
Use closest path if path not found

### DIFF
--- a/d2common/d2astar/README.md
+++ b/d2common/d2astar/README.md
@@ -7,9 +7,9 @@ D2 A*
 
 Changes
 -------
-* Used [sync.Pool](https://golang.org/pkg/sync/#Pool) to reuse objects created during pathfinding.  This improves performance by roughly 30% by reducing allocations.
-* Added a check on the target for neighbors to identify if the user clicked an inaccessible area.
+* Used [sync.Pool](https://golang.org/pkg/sync/#Pool) to reuse objects created during path-finding.  This improves performance by roughly 30% by reducing allocations.
 * Added a max cost to prevent searching the entire region for a path.
+* If there is no path the target within the max cost, the path found that gets closest to target will be returned.  This allows the player to click in inaccessible areas causing the character to run along the edge.
 
 TODO
 ------

--- a/d2core/d2map/d2mapengine/walk_mesh.go
+++ b/d2core/d2map/d2mapengine/walk_mesh.go
@@ -97,8 +97,14 @@ func (m *MapEngine) PathFind(startX, startY, endX, endY float64) (path []d2astar
 	}
 	endNode := &m.walkMesh[endNodeIndex]
 
-	path, distance, found = d2astar.Path(endNode, startNode, 80)
+	path, distance, found = d2astar.Path(startNode, endNode, 80)
 	if path != nil {
+		// Reverse the path to fit what the game expects.
+		for i := len(path)/2-1; i >= 0; i-- {
+			opp := len(path)-1-i
+			path[i], path[opp] = path[opp], path[i]
+		}
+
 		path = path[1:]
 	}
 	return

--- a/d2networking/d2client/game_client.go
+++ b/d2networking/d2client/game_client.go
@@ -86,8 +86,8 @@ func (g *GameClient) OnPacketReceived(packet d2netpacket.NetPacket) error {
 	case d2netpackettype.MovePlayer:
 		movePlayer := packet.PacketData.(d2netpacket.MovePlayerPacket)
 		player := g.Players[movePlayer.PlayerId]
-		path, _, found := g.MapEngine.PathFind(movePlayer.StartX, movePlayer.StartY, movePlayer.DestX, movePlayer.DestY)
-		if found {
+		path, _, _ := g.MapEngine.PathFind(movePlayer.StartX, movePlayer.StartY, movePlayer.DestX, movePlayer.DestY)
+		if len(path) > 0 {
 			player.AnimatedComposite.SetPath(path, func() {
 				tile := g.MapEngine.TileAt(player.TileX, player.TileY)
 				if tile == nil {


### PR DESCRIPTION
When clicking on the other side of a wall or in an an inaccessible area,
route the player the closest possible node.  This allows running along
walls and matches the original closely.