### PR TITLE
Switch to fork of coverage tool

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
         "golang.go",
-        "defaltd.go-coverage-viewer"
+        "soren.go-coverage-viewer"
     ]
 }


### PR DESCRIPTION
The existing suggestion for the code coverage viewer depends on the now unavailable ms-vscode.go extension.