### PR TITLE
Refactor escape

### DIFF
--- a/d2game/d2gamescreen/escape_menu.go
+++ b/d2game/d2gamescreen/escape_menu.go
@@ -1,4 +1,4 @@
-package d2player
+package d2gamescreen
 
 import (
 	"log"
@@ -8,6 +8,7 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2audio"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2input"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2render"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2screen"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2ui"
 )
 
@@ -49,7 +50,24 @@ func NewEscapeMenu() *EscapeMenu {
 	}
 }
 
+func (m *EscapeMenu) OnKeyDown(event d2input.KeyEvent) bool {
+	switch event.Key {
+	case d2input.KeyEscape:
+		m.Toggle()
+	case d2input.KeyUp:
+		m.OnUpKey()
+	case d2input.KeyDown:
+		m.OnDownKey()
+	case d2input.KeyEnter:
+		m.OnEnterKey()
+	default:
+		return false
+	}
+	return false
+}
+
 func (m *EscapeMenu) OnLoad() error {
+	d2input.BindHandler(m)
 	m.labels = []d2ui.Label{
 		d2ui.CreateLabel(d2resource.Font42, d2resource.PaletteSky),
 		d2ui.CreateLabel(d2resource.Font42, d2resource.PaletteSky),
@@ -231,6 +249,9 @@ func (m *EscapeMenu) onOptions() error {
 // User clicked on "SAVE AND EXIT"
 func (m *EscapeMenu) onSaveAndExit() error {
 	log.Println("SAVE AND EXIT GAME Clicked from Escape Menu")
+	mainMenu := CreateMainMenu()
+	mainMenu.SetScreenMode(ScreenModeMainMenu)
+	d2screen.SetNextScreen(mainMenu)
 	return nil
 }
 

--- a/d2game/d2gamescreen/game.go
+++ b/d2game/d2gamescreen/game.go
@@ -28,6 +28,7 @@ type Game struct {
 	localPlayer          *d2mapentity.Player
 	lastRegionType       d2enum.RegionIdType
 	ticksSinceLevelCheck float64
+	escapeMenu           *EscapeMenu
 }
 
 func CreateGame(gameClient *d2client.GameClient) *Game {
@@ -38,6 +39,7 @@ func CreateGame(gameClient *d2client.GameClient) *Game {
 		lastRegionType:       d2enum.RegionNone,
 		ticksSinceLevelCheck: 0,
 		mapRenderer:          d2maprenderer.CreateMapRenderer(gameClient.MapEngine),
+		escapeMenu:           NewEscapeMenu(),
 	}
 	return result
 }
@@ -64,13 +66,17 @@ func (v *Game) Render(screen d2render.Surface) error {
 		v.gameControls.Render(screen)
 	}
 
+	if v.escapeMenu.IsOpen() {
+		v.escapeMenu.Render(screen)
+	}
+
 	return nil
 }
 
 var hideZoneTextAfterSeconds = 2.0
 
 func (v *Game) Advance(tickTime float64) error {
-	if !v.gameControls.InEscapeMenu() || len(v.gameClient.Players) != 1 {
+	if !v.escapeMenu.IsOpen() || len(v.gameClient.Players) != 1 {
 		v.gameClient.MapEngine.Advance(tickTime) // TODO: Hack
 	}
 

--- a/d2game/d2gamescreen/game.go
+++ b/d2game/d2gamescreen/game.go
@@ -41,6 +41,8 @@ func CreateGame(gameClient *d2client.GameClient) *Game {
 		mapRenderer:          d2maprenderer.CreateMapRenderer(gameClient.MapEngine),
 		escapeMenu:           NewEscapeMenu(),
 	}
+	result.escapeMenu.OnLoad()
+	d2input.BindHandler(result.escapeMenu)
 	return result
 }
 
@@ -66,7 +68,7 @@ func (v *Game) Render(screen d2render.Surface) error {
 		v.gameControls.Render(screen)
 	}
 
-	if v.escapeMenu.IsOpen() {
+	if v.escapeMenu != nil {
 		v.escapeMenu.Render(screen)
 	}
 
@@ -76,7 +78,7 @@ func (v *Game) Render(screen d2render.Surface) error {
 var hideZoneTextAfterSeconds = 2.0
 
 func (v *Game) Advance(tickTime float64) error {
-	if !v.escapeMenu.IsOpen() || len(v.gameClient.Players) != 1 {
+	if (v.escapeMenu != nil && !v.escapeMenu.IsOpen()) || len(v.gameClient.Players) != 1 {
 		v.gameClient.MapEngine.Advance(tickTime) // TODO: Hack
 	}
 
@@ -124,6 +126,10 @@ func (v *Game) Advance(tickTime float64) error {
 
 			break
 		}
+	}
+
+	if v.escapeMenu.IsOpen() {
+		v.escapeMenu.Advance(tickTime)
 	}
 
 	// Update the camera to focus on the player

--- a/d2game/d2gamescreen/game.go
+++ b/d2game/d2gamescreen/game.go
@@ -52,6 +52,7 @@ func (v *Game) OnLoad(loading d2screen.LoadingState) {
 
 func (v *Game) OnUnload() error {
 	d2input.UnbindHandler(v.gameControls) // TODO: hack
+	v.gameClient.Close()
 	return nil
 }
 

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -30,12 +30,12 @@ type Panel interface {
 var missileID = 59
 
 type GameControls struct {
-	hero          *d2mapentity.Player
-	mapEngine     *d2mapengine.MapEngine
-	mapRenderer   *d2maprenderer.MapRenderer
-	inventory     *Inventory
-	heroStats     *HeroStats
-	escapeMenu    *EscapeMenu
+	hero        *d2mapentity.Player
+	mapEngine   *d2mapengine.MapEngine
+	mapRenderer *d2maprenderer.MapRenderer
+	inventory   *Inventory
+	heroStats   *HeroStats
+
 	inputListener InputCallbackListener
 	FreeCam       bool
 	lastMouseX    int
@@ -92,7 +92,6 @@ func NewGameControls(hero *d2mapentity.Player, mapEngine *d2mapengine.MapEngine,
 		mapRenderer:    mapRenderer,
 		inventory:      NewInventory(),
 		heroStats:      NewHeroStats(),
-		escapeMenu:     NewEscapeMenu(),
 		nameLabel:      &nameLabel,
 		zoneChangeText: &label,
 		actionableRegions: []ActionableRegion{
@@ -154,13 +153,6 @@ func (g *GameControls) OnKeyDown(event d2input.KeyEvent) bool {
 			g.updateLayout()
 			break
 		}
-		g.escapeMenu.Toggle()
-	case d2input.KeyUp:
-		g.escapeMenu.OnUpKey()
-	case d2input.KeyDown:
-		g.escapeMenu.OnDownKey()
-	case d2input.KeyEnter:
-		g.escapeMenu.OnEnterKey()
 	case d2input.KeyI:
 		g.inventory.Toggle()
 		g.updateLayout()
@@ -205,11 +197,6 @@ func (g *GameControls) OnMouseMove(event d2input.MouseMoveEvent) bool {
 	g.lastMouseX = mx
 	g.lastMouseY = my
 
-	if g.escapeMenu.IsOpen() {
-		g.escapeMenu.OnMouseMove(event)
-		return false
-	}
-
 	for i := range g.actionableRegions {
 		// Mouse over a game control element
 		if g.actionableRegions[i].Rect.IsInRect(mx, my) {
@@ -221,9 +208,6 @@ func (g *GameControls) OnMouseMove(event d2input.MouseMoveEvent) bool {
 }
 
 func (g *GameControls) OnMouseButtonDown(event d2input.MouseEvent) bool {
-	if g.escapeMenu.IsOpen() {
-		return g.escapeMenu.OnMouseButtonDown(event)
-	}
 
 	mx, my := event.X, event.Y
 	for i := range g.actionableRegions {
@@ -294,7 +278,6 @@ func (g *GameControls) Load() {
 
 	g.inventory.Load()
 	g.heroStats.Load()
-	g.escapeMenu.OnLoad()
 }
 
 func (g *GameControls) loadUIButtons() {
@@ -317,7 +300,6 @@ func (g *GameControls) onToggleRunButton() {
 
 // ScreenAdvanceHandler
 func (g *GameControls) Advance(elapsed float64) error {
-	g.escapeMenu.Advance(elapsed)
 	return nil
 }
 
@@ -350,19 +332,17 @@ func (g *GameControls) Render(target d2render.Surface) {
 		entScreenX := int(math.Floor(entScreenXf))
 		entScreenY := int(math.Floor(entScreenYf))
 
-		if ((entScreenX-20) <= g.lastMouseX) && ((entScreenX+20) >= g.lastMouseX) &&
-			((entScreenY-80) <= g.lastMouseY) && (entScreenY>= g.lastMouseY) {
+		if ((entScreenX - 20) <= g.lastMouseX) && ((entScreenX + 20) >= g.lastMouseX) &&
+			((entScreenY - 80) <= g.lastMouseY) && (entScreenY >= g.lastMouseY) {
 			g.nameLabel.SetText(entity.Name())
-			g.nameLabel.SetPosition(entScreenX, entScreenY - 100)
+			g.nameLabel.SetPosition(entScreenX, entScreenY-100)
 			g.nameLabel.Render(target)
 			break
 		}
 	}
 
-
 	g.inventory.Render(target)
 	g.heroStats.Render(target)
-	g.escapeMenu.Render(target)
 
 	width, height := target.GetSize()
 	offset := 0
@@ -458,9 +438,9 @@ func (g *GameControls) HideZoneChangeTextAfter(delay float64) {
 	})
 }
 
-func (g *GameControls) InEscapeMenu() bool {
-	return g != nil && g.escapeMenu != nil && g.escapeMenu.IsOpen()
-}
+// func (g *GameControls) InEscapeMenu() bool {
+// 	return g != nil && g.escapeMenu != nil && g.escapeMenu.IsOpen()
+// }
 
 // Handles what to do when an actionable is hovered
 func (g *GameControls) onHoverActionable(item ActionableType) {


### PR DESCRIPTION
I moved the escape menu from `d2player` to `d2gamescreen` because it was necessary to call `CreateMainMenu()` to exit the game.

Now clicking SAVE AND EXIT GAME kicks you back to the loading screen, then main menu.

New bug introduced is the unexpected player permanence. If you leave the game and re-enter, the previous player is still present where you left them. Do this a number of times, moving each player to a different location, to simulate a party with synchronized idle animations. See screenshot below. Essial reports entity handling is likely changing tomorrow, so I will revisit this once that is done, as I am not yet familiar with how that is handled.
<img width="804" alt="Screen Shot 2020-06-25 at 12 47 00 AM" src="https://user-images.githubusercontent.com/4504513/85667081-ce37f980-b682-11ea-9c4b-eeeecb8d73d0.png">

It looks like gofmt modified a few extra lines that I hadn't originally noticed.
