### PR TITLE
Object Highlights

### DIFF
--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -15,6 +15,8 @@ type MapEntity interface {
 	GetLayer() (int)
 	GetPositionF() (float64, float64)
 	Name() string
+	Selectable() bool
+	Highlight()
 }
 
 // mapEntity represents an entity on the map that can be animated
@@ -189,4 +191,11 @@ func (m *mapEntity) GetPositionF() (float64, float64) {
 
 func (m *mapEntity) Name() string {
 	return ""
+}
+
+func (m *mapEntity) Highlight() {
+}
+
+func (m *mapEntity) Selectable() bool {
+	return false
 }

--- a/d2core/d2map/d2mapentity/npc.go
+++ b/d2core/d2map/d2mapentity/npc.go
@@ -165,6 +165,14 @@ func (v *NPC) SetMode(animationMode, weaponClass string, direction int) error {
 	return err
 }
 
+func (m *NPC) Selectable() bool {
+	// is there something handy that determines selectable npc's?
+	if m.name != "" {
+		return true
+	}
+	return false
+}
+
 func (m *NPC) Name() string {
 	return m.name
 }

--- a/d2core/d2map/d2mapentity/player.go
+++ b/d2core/d2map/d2mapentity/player.go
@@ -207,3 +207,8 @@ func (v *Player) SetCasting() {
 	v.isCasting = true
 	v.SetAnimationMode(d2enum.AnimationModePlayerCast.String())
 }
+
+func (v *Player) Selectable() bool {
+	// Players are selectable when in town
+	return v.IsInTown()
+}

--- a/d2core/d2render/ebiten/ebiten_surface.go
+++ b/d2core/d2render/ebiten/ebiten_surface.go
@@ -38,6 +38,11 @@ func (s *ebitenSurface) PushColor(color color.Color) {
 	s.stateCurrent.color = color
 }
 
+func (s *ebitenSurface) PushBrightness(brightness float64) {
+	s.stateStack = append(s.stateStack, s.stateCurrent)
+	s.stateCurrent.brightness = brightness
+}
+
 func (s *ebitenSurface) Pop() {
 	count := len(s.stateStack)
 	if count == 0 {
@@ -60,6 +65,9 @@ func (s *ebitenSurface) Render(sfc d2render.Surface) error {
 	opts.Filter = s.stateCurrent.filter
 	if s.stateCurrent.color != nil {
 		opts.ColorM = ColorToColorM(s.stateCurrent.color)
+	}
+	if s.stateCurrent.brightness != 0 {
+		opts.ColorM.ChangeHSV(0, 1, s.stateCurrent.brightness)
 	}
 
 	var img = sfc.(*ebitenSurface).image

--- a/d2core/d2render/ebiten/surface_state.go
+++ b/d2core/d2render/ebiten/surface_state.go
@@ -12,4 +12,5 @@ type surfaceState struct {
 	mode   ebiten.CompositeMode
 	filter ebiten.Filter
 	color  color.Color
+	brightness float64
 }

--- a/d2core/d2render/surface.go
+++ b/d2core/d2render/surface.go
@@ -18,6 +18,7 @@ type Surface interface {
 	PushCompositeMode(mode CompositeMode)
 	PushFilter(filter Filter)
 	PushTranslation(x, y int)
+	PushBrightness(brightness float64)
 	Render(surface Surface) error
 	ReplacePixels(pixels []byte) error
 	Screenshot() *image.RGBA

--- a/d2game/d2gamescreen/game.go
+++ b/d2game/d2gamescreen/game.go
@@ -88,7 +88,6 @@ func (v *Game) Advance(tickTime float64) error {
 			tile := v.gameClient.MapEngine.TileAt(v.localPlayer.TileX, v.localPlayer.TileY)
 			if tile != nil {
 				musicInfo := d2common.GetMusicDef(tile.RegionType)
-				v.localPlayer.SetIsInTown(musicInfo.InTown)
 				d2audio.PlayBGM(musicInfo.MusicFile)
 
 				// skip showing zone change text the first time we enter the world

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -337,7 +337,7 @@ func (g *GameControls) isInActiveMenusRect(px int, py int) bool {
 func (g *GameControls) Render(target d2render.Surface) {
 	for entityIdx := range *g.mapEngine.Entities() {
 		entity := (*g.mapEngine.Entities())[entityIdx]
-		if entity.Name() == "" {
+		if !entity.Selectable() {
 			continue
 		}
 
@@ -350,6 +350,7 @@ func (g *GameControls) Render(target d2render.Surface) {
 			g.nameLabel.SetText(entity.Name())
 			g.nameLabel.SetPosition(entScreenX, entScreenY-100)
 			g.nameLabel.Render(target)
+			entity.Highlight()
 			break
 		}
 	}


### PR DESCRIPTION
 Add PushBrightness to surface 

Check if mapentity is selectable (seems reasonable), objects selectable according to their text record entry, players selectable if in town, npc's selectable if given a name (for now).

Request objects to highlight themselves if required (idk)