### PR TITLE
Fixes #496 and improves memory consumption on render of game_controls

### DIFF
--- a/d2common/d2interface/surface.go
+++ b/d2common/d2interface/surface.go
@@ -23,6 +23,8 @@ type Surface interface {
 	PushTranslation(x, y int)
 	PushBrightness(brightness float64)
 	Render(surface Surface) error
+	// Renders a section of the surface enclosed by bounds
+	RenderSection(surface Surface, bound image.Rectangle) error
 	ReplacePixels(pixels []byte) error
 	Screenshot() *image.RGBA
 }

--- a/d2core/d2asset/animation.go
+++ b/d2core/d2asset/animation.go
@@ -2,6 +2,7 @@ package d2asset
 
 import (
 	"errors"
+	"image"
 	"image/color"
 	"math"
 
@@ -277,6 +278,18 @@ func (a *Animation) RenderFromOrigin(target d2interface.Surface) error {
 	}
 
 	return a.Render(target)
+}
+
+// Renders the section of the animation frame enclosed by bounds
+func (a *Animation) RenderSection(sfc d2interface.Surface, bound image.Rectangle) error {
+	direction := a.directions[a.directionIndex]
+	frame := direction.frames[a.frameIndex]
+
+	sfc.PushTranslation(frame.offsetX, frame.offsetY)
+	sfc.PushCompositeMode(a.compositeMode)
+	sfc.PushColor(a.colorMod)
+	defer sfc.PopN(3)
+	return sfc.RenderSection(frame.image, bound)
 }
 
 func (a *Animation) GetFrameSize(frameIndex int) (int, int, error) {

--- a/d2core/d2render/ebiten/ebiten_surface.go
+++ b/d2core/d2render/ebiten/ebiten_surface.go
@@ -76,6 +76,22 @@ func (s *ebitenSurface) Render(sfc d2interface.Surface) error {
 	return s.image.DrawImage(img, opts)
 }
 
+// Renders the section of the animation frame enclosed by bounds
+func (s *ebitenSurface) RenderSection(sfc d2interface.Surface, bound image.Rectangle) error {
+	opts := &ebiten.DrawImageOptions{CompositeMode: s.stateCurrent.mode}
+	opts.GeoM.Translate(float64(s.stateCurrent.x), float64(s.stateCurrent.y))
+	opts.Filter = s.stateCurrent.filter
+	if s.stateCurrent.color != nil {
+		opts.ColorM = ColorToColorM(s.stateCurrent.color)
+	}
+	if s.stateCurrent.brightness != 0 {
+		opts.ColorM.ChangeHSV(0, 1, s.stateCurrent.brightness)
+	}
+
+	var img = sfc.(*ebitenSurface).image
+	return s.image.DrawImage(img.SubImage(bound).(*ebiten.Image), opts)
+}
+
 func (s *ebitenSurface) DrawText(format string, params ...interface{}) {
 	ebitenutil.DebugPrintAt(s.image, fmt.Sprintf(format, params...), s.stateCurrent.x, s.stateCurrent.y)
 }

--- a/d2core/d2ui/sprite.go
+++ b/d2core/d2ui/sprite.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
 )
 
+// Sprite is a positioned visual object.
 type Sprite struct {
 	x         int
 	y         int
@@ -33,21 +34,25 @@ func (s *Sprite) Render(target d2interface.Surface) error {
 
 	target.PushTranslation(s.x, s.y-frameHeight)
 	defer target.Pop()
+
 	return s.animation.Render(target)
 }
 
-// Renders the section of the sprite enclosed by bounds
+// RenderSection renders the section of the sprite enclosed by bounds
 func (s *Sprite) RenderSection(sfc d2interface.Surface, bound image.Rectangle) error {
 	sfc.PushTranslation(s.x, s.y-bound.Dy())
 	defer sfc.Pop()
+
 	return s.animation.RenderSection(sfc, bound)
 }
 
 func (s *Sprite) RenderSegmented(target d2interface.Surface, segmentsX, segmentsY, frameOffset int) error {
 	var currentY int
+
 	for y := 0; y < segmentsY; y++ {
 		var currentX int
 		var maxFrameHeight int
+
 		for x := 0; x < segmentsX; x++ {
 			if err := s.animation.SetCurrentFrame(x + y*segmentsX + frameOffset*segmentsX*segmentsY); err != nil {
 				return err
@@ -56,6 +61,7 @@ func (s *Sprite) RenderSegmented(target d2interface.Surface, segmentsX, segments
 			target.PushTranslation(s.x+currentX, s.y+currentY)
 			err := s.animation.Render(target)
 			target.Pop()
+
 			if err != nil {
 				return err
 			}
@@ -71,75 +77,93 @@ func (s *Sprite) RenderSegmented(target d2interface.Surface, segmentsX, segments
 	return nil
 }
 
+// SetPosition places the sprite in 2D
 func (s *Sprite) SetPosition(x, y int) {
 	s.x = x
 	s.y = y
 }
 
+// GetPosition retrieves the 2D position of the sprite
 func (s *Sprite) GetPosition() (int, int) {
 	return s.x, s.y
 }
 
+// GetFrameSize gets the Size(width, height) of a indexed frame.
 func (s *Sprite) GetFrameSize(frameIndex int) (int, int, error) {
 	return s.animation.GetFrameSize(frameIndex)
 }
 
+// GetCurrentFrameSize gets the Size(width, height) of the current frame.
 func (s *Sprite) GetCurrentFrameSize() (int, int) {
 	return s.animation.GetCurrentFrameSize()
 }
 
+// GetFrameBounds gets maximum Size(width, height) of all frame.
 func (s *Sprite) GetFrameBounds() (int, int) {
 	return s.animation.GetFrameBounds()
 }
 
+// GetCurrentFrame gets index of current frame in animation
 func (s *Sprite) GetCurrentFrame() int {
 	return s.animation.GetCurrentFrame()
 }
 
+// GetFrameCount gets number of frames in animation
 func (s *Sprite) GetFrameCount() int {
 	return s.animation.GetFrameCount()
 }
 
+// IsOnFirstFrame gets if the animation on its first frame
 func (s *Sprite) IsOnFirstFrame() bool {
 	return s.animation.IsOnFirstFrame()
 }
 
+// IsOnLastFrame gets if the animation on its last frame
 func (s *Sprite) IsOnLastFrame() bool {
 	return s.animation.IsOnLastFrame()
 }
 
+// GetDirectionCount gets the number of animation direction
 func (s *Sprite) GetDirectionCount() int {
 	return s.animation.GetDirectionCount()
 }
 
+// SetDirection places the animation in the direction of an animation
 func (s *Sprite) SetDirection(directionIndex int) error {
 	return s.animation.SetDirection(directionIndex)
 }
 
+// GetDirection get the current animation direction
 func (s *Sprite) GetDirection() int {
 	return s.animation.GetDirection()
 }
 
+// SetCurrentFrame sets animation at a specific frame
 func (s *Sprite) SetCurrentFrame(frameIndex int) error {
 	return s.animation.SetCurrentFrame(frameIndex)
 }
 
+// Rewind sprite to beginning
 func (s *Sprite) Rewind() {
 	s.animation.SetCurrentFrame(0)
 }
 
+// PlayForward plays sprite forward
 func (s *Sprite) PlayForward() {
 	s.animation.PlayForward()
 }
 
+// PlayBackward play sprites backward
 func (s *Sprite) PlayBackward() {
 	s.animation.PlayBackward()
 }
 
+// Pause animation
 func (s *Sprite) Pause() {
 	s.animation.Pause()
 }
 
+// SetPlayLoop sets whether to loop the animation
 func (s *Sprite) SetPlayLoop(loop bool) {
 	s.animation.SetPlayLoop(loop)
 }
@@ -156,6 +180,7 @@ func (s *Sprite) SetColorMod(color color.Color) {
 	s.animation.SetColorMod(color)
 }
 
+// SetBlend sets the animation alpha blending status
 func (s *Sprite) SetBlend(blend bool) {
 	s.animation.SetBlend(blend)
 }

--- a/d2core/d2ui/sprite.go
+++ b/d2core/d2ui/sprite.go
@@ -2,6 +2,7 @@ package d2ui
 
 import (
 	"errors"
+	"image"
 	"image/color"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
@@ -33,6 +34,13 @@ func (s *Sprite) Render(target d2interface.Surface) error {
 	target.PushTranslation(s.x, s.y-frameHeight)
 	defer target.Pop()
 	return s.animation.Render(target)
+}
+
+// Renders the section of the sprite enclosed by bounds
+func (s *Sprite) RenderSection(sfc d2interface.Surface, bound image.Rectangle) error {
+	sfc.PushTranslation(s.x, s.y-bound.Dy())
+	defer sfc.Pop()
+	return s.animation.RenderSection(sfc, bound)
 }
 
 func (s *Sprite) RenderSegmented(target d2interface.Surface, segmentsX, segmentsY, frameOffset int) error {

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -17,7 +17,6 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2map/d2mapengine"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2map/d2mapentity"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2map/d2maprenderer"
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2render"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2ui"
 )
 
@@ -49,14 +48,10 @@ type GameControls struct {
 	FreeCam           bool
 	lastMouseX        int
 	lastMouseY        int
-	lastHealthPercent float64
-	lastManaPercent   float64
 
 	// UI
 	globeSprite        *d2ui.Sprite
 	hpManaStatusSprite *d2ui.Sprite
-	hpStatusBar        d2interface.Surface
-	manaStatusBar      d2interface.Surface
 	mainPanel          *d2ui.Sprite
 	menuButton         *d2ui.Sprite
 	skillIcon          *d2ui.Sprite
@@ -256,8 +251,6 @@ func (g *GameControls) Load() {
 
 	animation, _ = d2asset.LoadAnimation(d2resource.HealthManaIndicator, d2resource.PaletteSky)
 	g.hpManaStatusSprite, _ = d2ui.LoadSprite(animation)
-
-	g.hpStatusBar, _ = d2render.NewSurface(globeWidth, globeHeight, d2interface.FilterNearest)
 
 	animation, _ = d2asset.LoadAnimation(d2resource.GamePanels, d2resource.PaletteSky)
 	g.mainPanel, _ = d2ui.LoadSprite(animation)

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -1,6 +1,7 @@
 package d2player
 
 import (
+	"image"
 	"image/color"
 	"log"
 	"math"
@@ -369,27 +370,17 @@ func (g *GameControls) Render(target d2interface.Surface) {
 	g.mainPanel.SetPosition(offset, height)
 	g.mainPanel.Render(target)
 
+	// Health status bar
+	healthPercent := float64(g.hero.Stats.Health) / float64(g.hero.Stats.MaxHealth)
+	hpBarHeight := int(healthPercent * float64(globeHeight))
+	g.hpManaStatusSprite.SetCurrentFrame(0)
+	g.hpManaStatusSprite.SetPosition(offset+30, height-13)
+	g.hpManaStatusSprite.RenderSection(target, image.Rect(0, globeHeight-hpBarHeight, globeWidth, globeHeight))
+
 	// Left globe
 	g.globeSprite.SetCurrentFrame(0)
 	g.globeSprite.SetPosition(offset+28, height-5)
 	g.globeSprite.Render(target)
-
-	// Health status bar
-	healthPercent := float64(g.hero.Stats.Health) / float64(g.hero.Stats.MaxHealth)
-	hpBarHeight := int(healthPercent * float64(globeHeight))
-	if g.lastHealthPercent != healthPercent {
-		g.hpStatusBar, _ = d2render.NewSurface(globeWidth, hpBarHeight, d2interface.FilterNearest)
-		g.hpManaStatusSprite.SetCurrentFrame(0)
-		g.hpStatusBar.PushTranslation(0, hpBarHeight)
-
-		g.hpManaStatusSprite.Render(g.hpStatusBar)
-		g.hpStatusBar.Pop()
-		g.lastHealthPercent = healthPercent
-	}
-
-	target.PushTranslation(30, 508+(globeHeight-hpBarHeight))
-	target.Render(g.hpStatusBar)
-	target.Pop()
 
 	offset += w
 
@@ -460,28 +451,18 @@ func (g *GameControls) Render(target d2interface.Surface) {
 	g.mainPanel.SetPosition(offset, height)
 	g.mainPanel.Render(target)
 
+	// Mana status bar
+	manaPercent := float64(g.hero.Stats.Mana) / float64(g.hero.Stats.MaxMana)
+	manaBarHeight := int(manaPercent * float64(globeHeight))
+	g.hpManaStatusSprite.SetCurrentFrame(1)
+	g.hpManaStatusSprite.SetPosition(offset+7, height-12)
+	g.hpManaStatusSprite.RenderSection(target, image.Rect(0, globeHeight-manaBarHeight, globeWidth, globeHeight))
+
 	// Right globe
 	g.globeSprite.SetCurrentFrame(1)
 	g.globeSprite.SetPosition(offset+8, height-8)
 	g.globeSprite.Render(target)
 	g.globeSprite.Render(target)
-
-	// Mana status bar
-	manaPercent := float64(g.hero.Stats.Mana) / float64(g.hero.Stats.MaxMana)
-	manaBarHeight := int(manaPercent * float64(globeHeight))
-	if manaPercent != g.lastManaPercent {
-		g.manaStatusBar, _ = d2render.NewSurface(globeWidth, manaBarHeight, d2interface.FilterNearest)
-		g.hpManaStatusSprite.SetCurrentFrame(1)
-
-		g.manaStatusBar.PushTranslation(0, manaBarHeight)
-		g.hpManaStatusSprite.Render(g.manaStatusBar)
-		g.manaStatusBar.Pop()
-
-		g.lastManaPercent = manaPercent
-	}
-	target.PushTranslation(offset+8, 508+(globeHeight-manaBarHeight))
-	target.Render(g.manaStatusBar)
-	target.Pop()
 
 	if g.isZoneTextShown {
 		g.zoneChangeText.SetPosition(width/2, height/4)


### PR DESCRIPTION
The main contributions are in `ebiten_surface.go` and `surface.go`. I added methods in Sprite and Animation to access the new surface functionality.

I tested for allocations and they seem normal, removed all old code to circumvent this issue, and fixed comment and spacing linting issues in Sprite and Animation.