### PR TITLE
d2hero is *nearly* lint free #487.

### DIFF
--- a/d2core/d2hero/hero_stats_state.go
+++ b/d2core/d2hero/hero_stats_state.go
@@ -1,3 +1,4 @@
+// Package d2hero utilities for managing a hero state.
 package d2hero
 
 import (
@@ -5,6 +6,7 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 )
 
+// HeroStatsState is a serializable state of hero stats.
 type HeroStatsState struct {
 	Level      int `json:"level"`
 	Experience int `json:"experience"`
@@ -33,29 +35,31 @@ type HeroStatsState struct {
 	NextLevelExp int
 }
 
-func CreateHeroStatsState(heroClass d2enum.Hero, classStats d2datadict.CharStatsRecord, level int, exp int) *HeroStatsState {
+// CreateHeroStatsState generates a running state from a hero stats.
+func CreateHeroStatsState(heroClass d2enum.Hero, classStats *d2datadict.CharStatsRecord) *HeroStatsState {
 	result := HeroStatsState{
-		Level:        level,
-		Experience:   exp,
-		NextLevelExp: d2datadict.GetExperienceBreakpoint(heroClass, 1), 
+		Level:        1,
+		Experience:   0,
+		NextLevelExp: d2datadict.GetExperienceBreakpoint(heroClass, 1),
 		Strength:     classStats.InitStr,
 		Dexterity:    classStats.InitDex,
 		Vitality:     classStats.InitVit,
 		Energy:       classStats.InitEne,
-		//TODO: proper formula for calculating health and mana
-		Health:     classStats.InitVit * classStats.LifePerVit / 4,
-		MaxHealth:  classStats.InitVit * classStats.LifePerVit / 4,
-		Mana:       classStats.InitEne * classStats.ManaPerEne / 4,
-		MaxMana:    classStats.InitEne * classStats.ManaPerEne / 4,
-		Stamina:    classStats.InitStamina,
+
+		MaxHealth:  classStats.InitVit * classStats.LifePerVit,
+		MaxMana:    classStats.InitEne * classStats.ManaPerEne,
 		MaxStamina: classStats.InitStamina,
-		//TODO chance to hit, defense rating
+		// TODO: chance to hit, defense rating
 	}
 
-	//TODO: those are added only for demonstration purposes(to show that hp mana exp status bars and character stats panel get updated depending on current stats)
-	result.Health /= 2
-	result.Mana /= 3
-	result.Experience = result.NextLevelExp / 3
+	result.Mana = result.MaxMana
+	result.Health = result.MaxHealth
+	result.Stamina = result.MaxStamina
+
+	// TODO: For demonstration purposes (hp, mana, exp, & character stats panel gets updated depending on stats)
+	result.Health = 20
+	result.Mana = 9
+	result.Experience = 166
 
 	return &result
 }

--- a/d2game/d2gamescreen/select_hero_class.go
+++ b/d2game/d2gamescreen/select_hero_class.go
@@ -438,7 +438,7 @@ func (v *SelectHeroClass) onExitButtonClicked() {
 }
 
 func (v *SelectHeroClass) onOkButtonClicked() {
-	gameState := d2player.CreatePlayerState(v.heroNameTextbox.GetText(), v.selectedHero, *d2datadict.CharStats[v.selectedHero], v.hardcoreCheckbox.GetCheckState())
+	gameState := d2player.CreatePlayerState(v.heroNameTextbox.GetText(), v.selectedHero, d2datadict.CharStats[v.selectedHero], v.hardcoreCheckbox.GetCheckState())
 	gameClient, _ := d2client.Create(d2clientconnectiontype.Local)
 	gameClient.Open(v.connectionHost, gameState.FilePath)
 	d2screen.SetNextScreen(CreateGame(v.audioProvider, gameClient, v.terminal))

--- a/d2game/d2player/player_state.go
+++ b/d2game/d2player/player_state.go
@@ -48,7 +48,7 @@ func GetAllPlayerStates() []*PlayerState {
 		// temporarily loading default class stats if the character was created before saving stats was introduced
 		// to be removed in the future
 		} else if gameState.Stats == nil {
-			gameState.Stats = d2hero.CreateHeroStatsState(gameState.HeroType, *d2datadict.CharStats[gameState.HeroType], 1, 0)
+			gameState.Stats = d2hero.CreateHeroStatsState(gameState.HeroType, d2datadict.CharStats[gameState.HeroType])
 			gameState.Save()
 		}
 
@@ -79,12 +79,12 @@ func LoadPlayerState(path string) *PlayerState {
 	return result
 }
 
-func CreatePlayerState(heroName string, hero d2enum.Hero, classStats d2datadict.CharStatsRecord, hardcore bool) *PlayerState {
+func CreatePlayerState(heroName string, hero d2enum.Hero, classStats *d2datadict.CharStatsRecord, hardcore bool) *PlayerState {
 	result := &PlayerState{
 		HeroName:  heroName,
 		HeroType:  hero,
 		Act:       1,
-		Stats: d2hero.CreateHeroStatsState(hero, classStats, 1, 0),
+		Stats: d2hero.CreateHeroStatsState(hero, classStats),
 		Equipment: d2inventory.HeroObjects[hero],
 		FilePath:  "",
 	}


### PR DESCRIPTION
Only lint left are meaningful TODOs.

I also defaulted the level and exp parameters as if we were to handle non-default state, we would need much more information. It might be worth creating another function at that point.

I also switch "d2datadict.CharStatsRecord" to pass by pointer instead of by copy, as suggested by the linter. Howerver, there might be a reason here to copy and ensure immutability. However, other calls in the path are all pass by pointer anyway.