### PR TITLE
Fixing D2GUI based event propagation with d2input. #531

### DIFF
--- a/d2core/d2gui/widget.go
+++ b/d2core/d2gui/widget.go
@@ -21,6 +21,8 @@ type widget interface {
 
 	getPosition() (int, int)
 	setOffset(x, y int)
+	SetScreenPos(x, y int)
+	ScreenPos() (x, y int)
 	getSize() (int, int)
 	getLayer() int
 	isVisible() bool
@@ -30,6 +32,8 @@ type widget interface {
 type widgetBase struct {
 	x         int
 	y         int
+	Sx		  int
+	Sy        int
 	layer     int
 	visible   bool
 	expanding bool
@@ -53,6 +57,16 @@ func (w *widgetBase) GetPosition() (int, int) {
 
 func (w *widgetBase) GetOffset() (int, int) {
 	return w.offsetX, w.offsetY
+}
+
+// SetScreenPos sets the screen position
+func (w *widgetBase) SetScreenPos(x, y int) {
+	w.Sx, w.Sy = x, y
+}
+
+// ScreenPos returns the screen position
+func (w *widgetBase) ScreenPos() (x, y int) {
+	return w.Sx, w.Sy
 }
 
 func (w *widgetBase) setOffset(x, y int) {


### PR DESCRIPTION
d2input made the move to immutable events. (ex. MouseMove) but
d2gui was using "local events" for its recursive layouts. Meaning
when entering a sub-layout, the original event was modified to have
the cursor relative to the x, and y of the parent layout.

After tossing ideas with Grav, we considered (1) making events modifiable,
(2) having an event constructor, (3) changing sub-Layout to use screen layout.

We choose (3), and this is the relevant commit.