### PR TITLE
Removing Clone of Font() since all material is sharable, Fixes #515

### DIFF
--- a/d2common/d2interface/font.go
+++ b/d2common/d2interface/font.go
@@ -4,10 +4,9 @@ import (
 	"image/color"
 )
 
-// Font is a font
+// Font is a graphical representation associated with a set of glyphs.
 type Font interface {
 	SetColor(c color.Color)
 	GetTextMetrics(text string) (width, height int)
-	Clone() Font
 	RenderText(text string, target Surface) error
 }

--- a/d2core/d2asset/font.go
+++ b/d2core/d2asset/font.go
@@ -42,6 +42,7 @@ func loadFont(tablePath, spritePath, palettePath string) (d2interface.Font, erro
 	_, maxCharHeight := sheet.GetFrameBounds()
 
 	glyphs := make(map[rune]fontGlyph)
+
 	for i := 12; i < len(data); i += 14 {
 		code := rune(binary.LittleEndian.Uint16(data[i : i+2]))
 
@@ -92,15 +93,6 @@ func (f *Font) GetTextMetrics(text string) (width, height int) {
 	totalHeight += lineHeight
 
 	return totalWidth, totalHeight
-}
-
-// Clone creates a shallow copy of the Font
-func (f *Font) Clone() d2interface.Font {
-	return &Font{
-		sheet:  f.sheet,
-		glyphs: f.glyphs,
-		color:  f.color,
-	}
 }
 
 // RenderText prints a text using its configured style on a Surface (multi-lines are left-aligned, use label otherwise)

--- a/d2core/d2asset/font_manager.go
+++ b/d2core/d2asset/font_manager.go
@@ -24,7 +24,7 @@ func (fm *fontManager) LoadFont(tablePath, spritePath, palettePath string) (d2in
 	error) {
 	cachePath := fmt.Sprintf("%s;%s;%s", tablePath, spritePath, palettePath)
 	if font, found := fm.cache.Retrieve(cachePath); found {
-		return font.(d2interface.Font).Clone(), nil
+		return font.(d2interface.Font), nil
 	}
 
 	font, err := loadFont(tablePath, spritePath, palettePath)
@@ -32,7 +32,7 @@ func (fm *fontManager) LoadFont(tablePath, spritePath, palettePath string) (d2in
 		return nil, err
 	}
 
-	if err := fm.cache.Insert(cachePath, font.Clone(), 1); err != nil {
+	if err := fm.cache.Insert(cachePath, font, 1); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Removed called to Clone and Clone from the interface.

All font with the same (tablePath, spritePath, palettePath string) tuple now share the same data.