### PR TITLE
Javascript console commands

### DIFF
--- a/d2core/d2term/terminal.go
+++ b/d2core/d2term/terminal.go
@@ -3,7 +3,6 @@ package d2term
 import (
 	"errors"
 	"fmt"
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 	"image/color"
 	"log"
 	"math"
@@ -12,9 +11,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
+
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-
 )
 
 // TermCategory applies styles to the lines in the  Terminal

--- a/d2core/d2term/terminal.go
+++ b/d2core/d2term/terminal.go
@@ -11,9 +11,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
 

--- a/d2game/d2gamescreen/character_select.go
+++ b/d2game/d2gamescreen/character_select.go
@@ -2,12 +2,15 @@ package d2gamescreen
 
 import (
 	"fmt"
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
 	"image/color"
 	"math"
 	"os"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2input"
 
@@ -48,6 +51,7 @@ type CharacterSelect struct {
 	connectionHost         string
 	audioProvider          d2interface.AudioProvider
 	terminal               d2interface.Terminal
+	scriptEngine           *d2script.ScriptEngine
 	renderer               d2interface.Renderer
 }
 
@@ -56,7 +60,7 @@ func CreateCharacterSelect(
 	renderer d2interface.Renderer,
 	audioProvider d2interface.AudioProvider,
 	connectionType d2clientconnectiontype.ClientConnectionType,
-	connectionHost string, term d2interface.Terminal,
+	connectionHost string, term d2interface.Terminal, scriptEngine *d2script.ScriptEngine,
 ) *CharacterSelect {
 	return &CharacterSelect{
 		selectedCharacter: -1,
@@ -65,6 +69,7 @@ func CreateCharacterSelect(
 		connectionHost:    connectionHost,
 		audioProvider:     audioProvider,
 		terminal:          term,
+		scriptEngine:      scriptEngine,
 	}
 }
 
@@ -211,11 +216,12 @@ func (v *CharacterSelect) updateCharacterBoxes() {
 }
 
 func (v *CharacterSelect) onNewCharButtonClicked() {
-	d2screen.SetNextScreen(CreateSelectHeroClass(v.renderer, v.audioProvider, v.connectionType, v.connectionHost, v.terminal))
+	d2screen.SetNextScreen(CreateSelectHeroClass(v.renderer, v.audioProvider, v.connectionType, v.connectionHost,
+		v.terminal, v.scriptEngine))
 }
 
 func (v *CharacterSelect) onExitButtonClicked() {
-	mainMenu := CreateMainMenu(v.renderer, v.audioProvider, v.terminal)
+	mainMenu := CreateMainMenu(v.renderer, v.audioProvider, v.terminal, v.scriptEngine)
 	mainMenu.setScreenMode(screenModeMainMenu)
 	d2screen.SetNextScreen(mainMenu)
 }
@@ -361,7 +367,7 @@ func (v *CharacterSelect) refreshGameStates() {
 }
 
 func (v *CharacterSelect) onOkButtonClicked() {
-	gameClient, _ := d2client.Create(v.connectionType)
+	gameClient, _ := d2client.Create(v.connectionType, v.scriptEngine)
 
 	host := ""
 	if v.connectionType == d2clientconnectiontype.LANClient {
@@ -373,5 +379,5 @@ func (v *CharacterSelect) onOkButtonClicked() {
 		fmt.Printf("can not connect to the host: %s", host)
 	}
 
-	d2screen.SetNextScreen(CreateGame(v.renderer, v.audioProvider, gameClient, v.terminal))
+	d2screen.SetNextScreen(CreateGame(v.renderer, v.audioProvider, gameClient, v.terminal, v.scriptEngine))
 }

--- a/d2game/d2gamescreen/character_select.go
+++ b/d2game/d2gamescreen/character_select.go
@@ -6,16 +6,12 @@ import (
 	"math"
 	"os"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2script"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2input"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2input"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2inventory"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2map/d2mapentity"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2screen"
@@ -23,6 +19,7 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2game/d2player"
 	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client"
 	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client/d2clientconnectiontype"
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 )
 
 // CharacterSelect represents the character select screen

--- a/d2game/d2gamescreen/credits.go
+++ b/d2game/d2gamescreen/credits.go
@@ -9,16 +9,13 @@ import (
 	"path"
 	"strings"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2script"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2screen"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2ui"
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 )
 
 type labelItem struct {

--- a/d2game/d2gamescreen/credits.go
+++ b/d2game/d2gamescreen/credits.go
@@ -9,6 +9,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
+
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
@@ -37,10 +39,11 @@ type Credits struct {
 	renderer           d2interface.Renderer
 	audioProvider      d2interface.AudioProvider
 	terminal           d2interface.Terminal
+	scriptEngine       *d2script.ScriptEngine
 }
 
 // CreateCredits creates an instance of the credits screen
-func CreateCredits(renderer d2interface.Renderer, audioProvider d2interface.AudioProvider) *Credits {
+func CreateCredits(renderer d2interface.Renderer, audioProvider d2interface.AudioProvider, scriptEngine *d2script.ScriptEngine) *Credits {
 	result := &Credits{
 		labels:             make([]*labelItem, 0),
 		cycleTime:          0,
@@ -48,6 +51,7 @@ func CreateCredits(renderer d2interface.Renderer, audioProvider d2interface.Audi
 		cyclesTillNextLine: 0,
 		renderer:           renderer,
 		audioProvider:      audioProvider,
+		scriptEngine:       scriptEngine,
 	}
 
 	return result
@@ -159,7 +163,7 @@ func (v *Credits) Advance(tickTime float64) error {
 }
 
 func (v *Credits) onExitButtonClicked() {
-	mainMenu := CreateMainMenu(v.renderer, v.audioProvider, v.terminal)
+	mainMenu := CreateMainMenu(v.renderer, v.audioProvider, v.terminal, v.scriptEngine)
 	mainMenu.setScreenMode(screenModeMainMenu)
 	d2screen.SetNextScreen(mainMenu)
 }

--- a/d2game/d2gamescreen/escape_menu.go
+++ b/d2game/d2gamescreen/escape_menu.go
@@ -2,6 +2,9 @@ package d2gamescreen
 
 import (
 	"fmt"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
+
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
@@ -71,6 +74,7 @@ type EscapeMenu struct {
 	renderer      d2interface.Renderer
 	audioProvider d2interface.AudioProvider
 	terminal      d2interface.Terminal
+	scriptEngine  *d2script.ScriptEngine
 }
 
 type layout struct {
@@ -124,11 +128,13 @@ type actionableElement interface {
 }
 
 // NewEscapeMenu creates a new escape menu
-func NewEscapeMenu(renderer d2interface.Renderer, audioProvider d2interface.AudioProvider, term d2interface.Terminal) *EscapeMenu {
+func NewEscapeMenu(renderer d2interface.Renderer, audioProvider d2interface.AudioProvider, term d2interface.Terminal,
+	scriptEngine *d2script.ScriptEngine) *EscapeMenu {
 	m := &EscapeMenu{
 		audioProvider: audioProvider,
 		terminal:      term,
 		renderer:      renderer,
+		scriptEngine:  scriptEngine,
 	}
 
 	m.layouts = []*layout{
@@ -368,7 +374,7 @@ func (m *EscapeMenu) showLayout(id layoutID) {
 	}
 
 	if id == saveLayoutID {
-		mainMenu := CreateMainMenu(m.renderer, m.audioProvider, m.terminal)
+		mainMenu := CreateMainMenu(m.renderer, m.audioProvider, m.terminal, m.scriptEngine)
 		mainMenu.setScreenMode(screenModeMainMenu)
 		d2screen.SetNextScreen(mainMenu)
 

--- a/d2game/d2gamescreen/escape_menu.go
+++ b/d2game/d2gamescreen/escape_menu.go
@@ -3,15 +3,12 @@ package d2gamescreen
 import (
 	"fmt"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2script"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2screen"
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 )
 
 // TODO: fix pentagram

--- a/d2game/d2gamescreen/game.go
+++ b/d2game/d2gamescreen/game.go
@@ -1,25 +1,21 @@
 package d2gamescreen
 
 import (
+	"fmt"
 	"image/color"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2script"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2screen"
-
-	"fmt"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2data/d2datadict"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2input"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2map/d2mapentity"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2map/d2maprenderer"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2screen"
 	"github.com/OpenDiablo2/OpenDiablo2/d2game/d2player"
 	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client"
 	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2netpacket"
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 )
 
 const hideZoneTextAfterSeconds = 2.0

--- a/d2game/d2gamescreen/game.go
+++ b/d2game/d2gamescreen/game.go
@@ -3,6 +3,8 @@ package d2gamescreen
 import (
 	"image/color"
 
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
+
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 
@@ -39,7 +41,7 @@ type Game struct {
 
 // CreateGame creates the Gameplay screen and returns a pointer to it
 func CreateGame(renderer d2interface.Renderer, audioProvider d2interface.AudioProvider, gameClient *d2client.GameClient,
-	term d2interface.Terminal) *Game {
+	term d2interface.Terminal, scriptEngine *d2script.ScriptEngine) *Game {
 	result := &Game{
 		gameClient:           gameClient,
 		gameControls:         nil,
@@ -47,7 +49,7 @@ func CreateGame(renderer d2interface.Renderer, audioProvider d2interface.AudioPr
 		lastRegionType:       d2enum.RegionNone,
 		ticksSinceLevelCheck: 0,
 		mapRenderer:          d2maprenderer.CreateMapRenderer(renderer, gameClient.MapEngine, term),
-		escapeMenu:           NewEscapeMenu(renderer, audioProvider, term),
+		escapeMenu:           NewEscapeMenu(renderer, audioProvider, term, scriptEngine),
 		audioProvider:        audioProvider,
 		renderer:             renderer,
 		terminal:             term,

--- a/d2game/d2gamescreen/main_menu.go
+++ b/d2game/d2gamescreen/main_menu.go
@@ -3,13 +3,15 @@ package d2gamescreen
 
 import (
 	"fmt"
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
 	"image/color"
 	"log"
 	"os"
 	"os/exec"
 	"runtime"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 
@@ -75,16 +77,19 @@ type MainMenu struct {
 	renderer            d2interface.Renderer
 	audioProvider       d2interface.AudioProvider
 	terminal            d2interface.Terminal
+	scriptEngine        *d2script.ScriptEngine
 }
 
 // CreateMainMenu creates an instance of MainMenu
-func CreateMainMenu(renderer d2interface.Renderer, audioProvider d2interface.AudioProvider, term d2interface.Terminal) *MainMenu {
+func CreateMainMenu(renderer d2interface.Renderer, audioProvider d2interface.AudioProvider, term d2interface.Terminal,
+	scriptEngine *d2script.ScriptEngine) *MainMenu {
 	return &MainMenu{
 		screenMode:     screenModeUnknown,
 		leftButtonHeld: true,
 		renderer:       renderer,
 		audioProvider:  audioProvider,
 		terminal:       term,
+		scriptEngine:   scriptEngine,
 	}
 }
 
@@ -154,7 +159,7 @@ func (v *MainMenu) createLabels(loading d2screen.LoadingState) {
 	loading.Progress(0.3)
 
 	v.copyrightLabel2 = d2ui.CreateLabel(d2resource.FontFormal12, d2resource.PaletteStatic)
-	v.copyrightLabel2.Alignment =d2gui.HorizontalAlignCenter
+	v.copyrightLabel2.Alignment = d2gui.HorizontalAlignCenter
 	v.copyrightLabel2.SetText("All Rights Reserved.")
 	v.copyrightLabel2.Color = color.RGBA{R: 188, G: 168, B: 140, A: 255}
 	v.copyrightLabel2.SetPosition(400, 525)
@@ -287,12 +292,12 @@ func (v *MainMenu) onSinglePlayerClicked() {
 	// Go here only if existing characters are available to select
 	if d2player.HasGameStates() {
 		d2screen.SetNextScreen(CreateCharacterSelect(v.renderer, v.audioProvider, d2clientconnectiontype.Local,
-			v.tcpJoinGameEntry.GetText(), v.terminal))
+			v.tcpJoinGameEntry.GetText(), v.terminal, v.scriptEngine))
 		return
 	}
 
 	d2screen.SetNextScreen(CreateSelectHeroClass(v.renderer, v.audioProvider,
-		d2clientconnectiontype.Local, v.tcpJoinGameEntry.GetText(), v.terminal))
+		d2clientconnectiontype.Local, v.tcpJoinGameEntry.GetText(), v.terminal, v.scriptEngine))
 }
 
 func (v *MainMenu) onGithubButtonClicked() {
@@ -321,7 +326,7 @@ func (v *MainMenu) onExitButtonClicked() {
 }
 
 func (v *MainMenu) onCreditsButtonClicked() {
-	d2screen.SetNextScreen(CreateCredits(v.renderer, v.audioProvider))
+	d2screen.SetNextScreen(CreateCredits(v.renderer, v.audioProvider, v.scriptEngine))
 }
 
 // Render renders the main menu
@@ -487,7 +492,7 @@ func (v *MainMenu) onTCPIPCancelClicked() {
 
 func (v *MainMenu) onTCPIPHostGameClicked() {
 	d2screen.SetNextScreen(CreateCharacterSelect(v.renderer, v.audioProvider,
-		d2clientconnectiontype.LANServer, "", v.terminal))
+		d2clientconnectiontype.LANServer, "", v.terminal, v.scriptEngine))
 }
 
 func (v *MainMenu) onTCPIPJoinGameClicked() {
@@ -500,5 +505,5 @@ func (v *MainMenu) onBtnTCPIPCancelClicked() {
 
 func (v *MainMenu) onBtnTCPIPOkClicked() {
 	d2screen.SetNextScreen(CreateCharacterSelect(v.renderer, v.audioProvider,
-		d2clientconnectiontype.LANClient, v.tcpJoinGameEntry.GetText(), v.terminal))
+		d2clientconnectiontype.LANClient, v.tcpJoinGameEntry.GetText(), v.terminal, v.scriptEngine))
 }

--- a/d2game/d2gamescreen/main_menu.go
+++ b/d2game/d2gamescreen/main_menu.go
@@ -9,24 +9,18 @@ import (
 	"os/exec"
 	"runtime"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
-	"github.com/OpenDiablo2/OpenDiablo2/d2script"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2input"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2game/d2player"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client/d2clientconnectiontype"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2input"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2screen"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2ui"
+	"github.com/OpenDiablo2/OpenDiablo2/d2game/d2player"
+	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client/d2clientconnectiontype"
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 )
 
 type mainMenuScreenMode int

--- a/d2game/d2gamescreen/select_hero_class.go
+++ b/d2game/d2gamescreen/select_hero_class.go
@@ -2,9 +2,12 @@ package d2gamescreen
 
 import (
 	"fmt"
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
 	"image"
 	"image/color"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 
@@ -187,6 +190,7 @@ type SelectHeroClass struct {
 	audioProvider      d2interface.AudioProvider
 	terminal           d2interface.Terminal
 	renderer           d2interface.Renderer
+	scriptEngine       *d2script.ScriptEngine
 }
 
 // CreateSelectHeroClass creates an instance of a SelectHeroClass
@@ -196,6 +200,7 @@ func CreateSelectHeroClass(
 	connectionType d2clientconnectiontype.ClientConnectionType,
 	connectionHost string,
 	terminal d2interface.Terminal,
+	scriptEngine *d2script.ScriptEngine,
 ) *SelectHeroClass {
 	result := &SelectHeroClass{
 		heroRenderInfo: make(map[d2enum.Hero]*HeroRenderInfo),
@@ -205,6 +210,7 @@ func CreateSelectHeroClass(
 		audioProvider:  audioProvider,
 		terminal:       terminal,
 		renderer:       renderer,
+		scriptEngine:   scriptEngine,
 	}
 
 	return result
@@ -341,7 +347,7 @@ func (v *SelectHeroClass) OnUnload() error {
 
 func (v *SelectHeroClass) onExitButtonClicked() {
 	d2screen.SetNextScreen(CreateCharacterSelect(v.renderer, v.audioProvider, v.connectionType,
-		v.connectionHost, v.terminal))
+		v.connectionHost, v.terminal, v.scriptEngine))
 }
 
 func (v *SelectHeroClass) onOkButtonClicked() {
@@ -351,13 +357,13 @@ func (v *SelectHeroClass) onOkButtonClicked() {
 		d2datadict.CharStats[v.selectedHero],
 		v.hardcoreCheckbox.GetCheckState(),
 	)
-	gameClient, _ := d2client.Create(d2clientconnectiontype.Local)
+	gameClient, _ := d2client.Create(d2clientconnectiontype.Local, v.scriptEngine)
 
 	if err := gameClient.Open(v.connectionHost, gameState.FilePath); err != nil {
 		fmt.Printf("can not connect to the host: %s\n", v.connectionHost)
 	}
 
-	d2screen.SetNextScreen(CreateGame(v.renderer, v.audioProvider, gameClient, v.terminal))
+	d2screen.SetNextScreen(CreateGame(v.renderer, v.audioProvider, gameClient, v.terminal, v.scriptEngine))
 }
 
 // Render renders the Select Hero Class screen

--- a/d2game/d2gamescreen/select_hero_class.go
+++ b/d2game/d2gamescreen/select_hero_class.go
@@ -5,25 +5,19 @@ import (
 	"image"
 	"image/color"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2script"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2game/d2player"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client"
-	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client/d2clientconnectiontype"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2data/d2datadict"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2screen"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2ui"
+	"github.com/OpenDiablo2/OpenDiablo2/d2game/d2player"
+	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client"
+	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client/d2clientconnectiontype"
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 )
 
 type heroRenderConfig struct {

--- a/d2networking/d2client/game_client.go
+++ b/d2networking/d2client/game_client.go
@@ -73,7 +73,7 @@ func (g *GameClient) Open(connectionString string, saveFilePath string) error {
 func (g *GameClient) Close() error {
 	switch g.connectionType {
 	case d2clientconnectiontype.LANServer, d2clientconnectiontype.Local:
-		g.scriptEngine.Reset()
+		g.scriptEngine.DisallowEval()
 	}
 	return g.clientConnection.Close()
 }

--- a/d2networking/d2client/game_client.go
+++ b/d2networking/d2client/game_client.go
@@ -5,23 +5,19 @@ import (
 	"log"
 	"os"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2script"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2data/d2datadict"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2map/d2mapgen"
-
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2map/d2mapengine"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2map/d2mapentity"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2map/d2mapgen"
 	"github.com/OpenDiablo2/OpenDiablo2/d2game/d2player"
 	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client/d2clientconnectiontype"
 	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client/d2localclient"
 	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client/d2remoteclient"
 	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2netpacket"
 	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2netpacket/d2netpackettype"
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 )
 
 // GameClient manages a connection to d2server.GameServer

--- a/d2script/engine.go
+++ b/d2script/engine.go
@@ -18,9 +18,18 @@ type ScriptEngine struct {
 
 // CreateScriptEngine creates the script engine and returns a pointer to it.
 func CreateScriptEngine() *ScriptEngine {
-	engine := &ScriptEngine{}
-	engine.Reset()
-	return engine
+	vm := otto.New()
+	err := vm.Set("debugPrint", func(call otto.FunctionCall) otto.Value {
+		fmt.Printf("Script: %s\n", call.Argument(0).String())
+		return otto.Value{}
+	})
+	if err != nil {
+		fmt.Printf("could not bind the 'debugPrint' to the given function in script engine")
+	}
+	return &ScriptEngine{
+		vm:            vm,
+		isEvalAllowed: false,
+	}
 }
 
 // AllowEval allows the evaluation of JS code.
@@ -31,20 +40,6 @@ func (s *ScriptEngine) AllowEval() {
 // AllowEval disallows the evaluation of JS code.
 func (s *ScriptEngine) DisallowEval() {
 	s.isEvalAllowed = false
-}
-
-// Reset the engine by creating a new VM and assigning default functions.
-func (s *ScriptEngine) Reset() {
-	vm := otto.New()
-	err := vm.Set("debugPrint", func(call otto.FunctionCall) otto.Value {
-		fmt.Printf("Script: %s\n", call.Argument(0).String())
-		return otto.Value{}
-	})
-	if err != nil {
-		fmt.Printf("could not bind the 'debugPrint' to the given function in script engine")
-	}
-	s.DisallowEval()
-	s.vm = vm
 }
 
 // ToValue converts the given interface{} value to a otto.Value

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
+
 	"github.com/OpenDiablo2/OpenDiablo2/d2app"
 	ebiten2 "github.com/OpenDiablo2/OpenDiablo2/d2core/d2audio/ebiten"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2config"
@@ -40,12 +42,13 @@ func main() {
 
 	d2input.Create() // TODO d2input singleton must be init before d2term
 	term, err := d2term.Initialize()
-
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	app := d2app.Create(GitBranch, GitCommit, term, audio, renderer)
+	scriptEngine := d2script.CreateScriptEngine()
+
+	app := d2app.Create(GitBranch, GitCommit, term, scriptEngine, audio, renderer)
 	if err := app.Run(); err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -3,14 +3,13 @@ package main
 import (
 	"log"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2script"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2app"
 	ebiten2 "github.com/OpenDiablo2/OpenDiablo2/d2core/d2audio/ebiten"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2config"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2input"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2render/ebiten"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2term"
+	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 )
 
 // GitBranch is set by the CI build process to the name of the branch


### PR DESCRIPTION
Closes #367 

# Work done

* Add the possibility to evaluate JS code in the script engine
* Bind the script engine's `Eval` to the `js` command in the terminal
* Allow the evaluation of JS code in a single-player game, or if hosting a local multiplayer game

# Known issues & improvements
* The script engine isn't reset between games - it might be interesting later to create a new instance of a script engine every time a game starts, or at least reset the JS VM
* The way commands are handled should be improved so as to support plain string commands without parsing them (escaping, separating params using spaces, etc.). For instance, right now `js foo = "bar"` won't work as the terminal tries to escape the command. I didn't make the fix as it seemed to be out of the scope of this issue and it would impact a lot more than just the JS console command
* _There is a bug when joining a local multiplayer game (black screen - see last screenshot)_

# Screenshots

## Main menu (disabled)
<img width="799" alt="Screenshot 2020-07-10 at 23 45 05" src="https://user-images.githubusercontent.com/1004323/87205395-a47c0500-c307-11ea-84d4-6b0a9f3e6d53.png">

## Single-player game (enabled)
<img width="797" alt="Screenshot 2020-07-10 at 23 45 36" src="https://user-images.githubusercontent.com/1004323/87205409-ac3ba980-c307-11ea-8bbd-680dd490e1ee.png">

## Multiplayer game, hosting (enabled)
<img width="799" alt="Screenshot 2020-07-10 at 23 45 56" src="https://user-images.githubusercontent.com/1004323/87205429-b6f63e80-c307-11ea-8801-e0866165e920.png">

## Multiplayer game, joining (disabled)
<img width="795" alt="Screenshot 2020-07-10 at 23 46 42" src="https://user-images.githubusercontent.com/1004323/87205438-bd84b600-c307-11ea-87a1-a77c7ef962b6.png">
