### PR TITLE
Map entity rework - vectors in mapEntity

### DIFF
--- a/d2common/d2math/d2vector/position.go
+++ b/d2common/d2math/d2vector/position.go
@@ -99,11 +99,10 @@ func (p *Position) Offset() *Vector {
 	return &v
 }
 
-// TODO: rename this to RenderOffset
-// RenderOffset is SubTileOffset() + 1. This places the vector in at the bottom vertex of this sub tile, which is a
-// diamond in the isometric space.
-// SubTile indices increase to the lower right diagonal ('down') and to the lower left diagonal ('left').
-func (p *Position) SubCell() *Vector {
+// RenderOffset is SubTileOffset() + 1. This places the vector at the bottom vertex of an isometric diamond visually
+// representing one sub tile. Sub tile indices increase to the lower right diagonal ('down') and to the lower left
+// diagonal ('left') of the isometric grid. This renders the target one index above which visually is one tile below.
+func (p *Position) RenderOffset() *Vector {
 	return p.SubTileOffset().AddScalar(1)
 }
 
@@ -130,8 +129,4 @@ func (v *Vector) DirectionTo(target Vector) int {
 	}
 
 	return newDirection
-}
-
-func (p Position) String() string {
-	return fmt.Sprintf("World: %s\nTile: %s\nSubWorld: %s\nSubCell: %s\nSubTileOffset: %s", p.World(), p.Tile(), p.WorldSubTile(), p.SubCell(), p.SubTileOffset())
 }

--- a/d2common/d2math/d2vector/position.go
+++ b/d2common/d2math/d2vector/position.go
@@ -70,22 +70,22 @@ func (p *Position) TileOffset() *Vector {
 	return c.Subtract(p.Tile())
 }
 
-// SubWorld is the position, where 5 = one map tile. (locationX, locationY)
-func (p *Position) SubWorld() *Vector {
+// WorldSubTile is the position, where 5 = one map tile. (locationX, locationY)
+func (p *Position) WorldSubTile() *Vector {
 	c := p.World().Clone()
 	return c.Scale(subTilesPerTile)
 }
 
-// SubTile is the tile position in sub tiles, always a multiple of 5.
+// TileSubTile is the tile position in sub tiles, always a multiple of 5.
 // unused
-func (p *Position) SubTile() *Vector {
+func (p *Position) TileSubTile() *Vector {
 	return p.Tile().Scale(subTilesPerTile)
 }
 
 // SubTileOffset is the offset from the sub tile position in sub tiles, always < 1.
 // unused
 func (p *Position) SubTileOffset() *Vector {
-	return p.SubWorld().Subtract(p.SubTile())
+	return p.WorldSubTile().Subtract(p.TileSubTile())
 }
 
 // This original value here was always zero. It is never assigned to but it is used. (offsetX, offsetY)
@@ -104,5 +104,5 @@ func (p *Position) SubCell() *Vector {
 }
 
 func (p Position) String() string {
-	return fmt.Sprintf("World: %s\nTile: %s\nSubWorld: %s\nSubCell: %s", p.World(), p.Tile(), p.SubWorld(), p.SubCell())
+	return fmt.Sprintf("World: %s\nTile: %s\nSubWorld: %s\nSubCell: %s", p.World(), p.Tile(), p.WorldSubTile(), p.SubCell())
 }

--- a/d2common/d2math/d2vector/position.go
+++ b/d2common/d2math/d2vector/position.go
@@ -67,6 +67,7 @@ func (p *Position) RenderOffset() *Vector {
 func (p *Position) subTileOffset() *Vector {
 	t := p.Tile().Scale(subTilesPerTile)
 	c := p.Clone()
+
 	return c.Subtract(t)
 }
 

--- a/d2common/d2math/d2vector/position.go
+++ b/d2common/d2math/d2vector/position.go
@@ -24,13 +24,20 @@ func NewPosition(x, y float64) Position {
 // The value given should be the one set in d2mapstamp.Stamp.Entities:
 // (tileOffsetX*5)+object.X, (tileOffsetY*5)+object.Y
 // TODO: This probably doesn't support positions in between sub tiles so will only be suitable for spawning entities from map generation, not for multiplayer syncing.
-func EntityPosition(x, y int) Position {
-	return NewPosition(float64(x)/5, float64(y)/5)
+func EntityPosition(x, y float64) Position {
+	return NewPosition(x/5, y/5)
 }
 
-// Set sets this position to the given x and y values.
+// Set sets this position to the given x and y world position.
 func (p *Position) Set(x, y float64) {
 	p.x, p.y = x, y
+	p.checkValues()
+}
+
+// TODO: test this
+// SetSubWorld sets this position to the given x and y sub tile coordinates.
+func (p *Position) SetSubWorld(x, y float64) {
+	p.x, p.y = x/5, y/5
 	p.checkValues()
 }
 
@@ -44,8 +51,8 @@ func (p *Position) checkValues() {
 	}
 }
 
-// World is the position, where 1 = one map tile.
-// unused
+// World is the position, where 1 = one map tile. This is a pointer to the Position value and must be cloned with
+// Clone() if the position is not to be changed.
 func (p *Position) World() *Vector {
 	return &p.Vector
 }
@@ -81,6 +88,12 @@ func (p *Position) SubTileOffset() *Vector {
 	return p.SubWorld().Subtract(p.SubTile())
 }
 
+// This original value here was always zero. It is never assigned to but it is used. (offsetX, offsetY)
+func (p *Position) Offset() *Vector {
+	v := VectorZero()
+	return &v
+}
+
 // TODO: understand this and maybe improve/remove it
 // SubTileOffset() + 1. It's used for rendering. It seems to always do this:
 // 	v.offsetX+int((v.subcellX-v.subcellY)*16),
@@ -88,4 +101,8 @@ func (p *Position) SubTileOffset() *Vector {
 // ^ Maybe similar to Viewport.OrthoToWorld? (subCellX, subCellY)
 func (p *Position) SubCell() *Vector {
 	return p.SubTileOffset().AddScalar(1)
+}
+
+func (p Position) String() string {
+	return fmt.Sprintf("World: %s\nTile: %s\nSubWorld: %s\nSubCell: %s", p.World(), p.Tile(), p.SubWorld(), p.SubCell())
 }

--- a/d2common/d2math/d2vector/position.go
+++ b/d2common/d2math/d2vector/position.go
@@ -10,7 +10,8 @@ import (
 const (
 	subTilesPerTile          float64 = 5  // The number of sub tiles that make up one map tile.
 	entityDirectionCount     float64 = 64 // The Diablo equivalent of 360 degrees when dealing with entity rotation.
-	entityDirectionIncrement float64 = 8  // One 8th of 64. There are 8 possible facing directions for moving entities.
+	entityDirectionIncrement float64 = 8  // One 8th of 64. There 8 possible facing directions for entities.
+	// Note: there should be 16 facing directions for entities. See Position.DirectionTo()
 )
 
 // Position is a vector in world space. The stored value is the sub tile position.
@@ -18,7 +19,8 @@ type Position struct {
 	Vector
 }
 
-// NewPosition returns a Position struct with a vector at the given x and y sub tile coordinates.
+// NewPosition returns a Position struct with the given sub tile coordinates where 1 = 1 sub tile, with a fractional
+// offset.
 func NewPosition(x, y float64) Position {
 	p := Position{NewVector(x, y)}
 	p.checkValues()
@@ -26,7 +28,7 @@ func NewPosition(x, y float64) Position {
 	return p
 }
 
-// Set sets this position to the given x and y sub tile coordinates.
+// Set sets this position to the given sub tile coordinates where 1 = 1 sub tile, with a fractional offset.
 func (p *Position) Set(x, y float64) {
 	p.x, p.y = x, y
 	p.checkValues()
@@ -69,7 +71,6 @@ func (p *Position) subTileOffset() *Vector {
 }
 
 // DirectionTo returns the entity direction from this vector to the given vector.
-// See entityDirectionCount.
 func (v *Vector) DirectionTo(target Vector) int {
 	direction := target.Clone()
 	direction.Subtract(v)
@@ -79,7 +80,7 @@ func (v *Vector) DirectionTo(target Vector) int {
 
 	// Note: The direction is always one increment out so we must subtract one increment.
 	// This might not work when we implement all 16 directions (as of this writing entities can only face one of 8
-	// directions)
+	// directions). See entityDirectionIncrement.
 	newDirection := int((angle / radiansPerDirection) - entityDirectionIncrement)
 
 	return d2math.WrapInt(newDirection, int(entityDirectionCount))

--- a/d2common/d2math/d2vector/position.go
+++ b/d2common/d2math/d2vector/position.go
@@ -104,5 +104,5 @@ func (p *Position) SubCell() *Vector {
 }
 
 func (p Position) String() string {
-	return fmt.Sprintf("World: %s\nTile: %s\nSubWorld: %s\nSubCell: %s", p.World(), p.Tile(), p.WorldSubTile(), p.SubCell())
+	return fmt.Sprintf("World: %s\nTile: %s\nSubWorld: %s\nSubCell: %s\nSubTileOffset: %s", p.World(), p.Tile(), p.WorldSubTile(), p.SubCell(), p.SubTileOffset())
 }

--- a/d2common/d2math/d2vector/position.go
+++ b/d2common/d2math/d2vector/position.go
@@ -93,12 +93,6 @@ func (p *Position) SubTileOffset() *Vector {
 	return p.WorldSubTile().Subtract(p.TileSubTile())
 }
 
-// This original value here was always zero. It is never assigned to but it is used. (offsetX, offsetY)
-func (p *Position) Offset() *Vector {
-	v := VectorZero()
-	return &v
-}
-
 // RenderOffset is SubTileOffset() + 1. This places the vector at the bottom vertex of an isometric diamond visually
 // representing one sub tile. Sub tile indices increase to the lower right diagonal ('down') and to the lower left
 // diagonal ('left') of the isometric grid. This renders the target one index above which visually is one tile below.
@@ -120,13 +114,5 @@ func (v *Vector) DirectionTo(target Vector) int {
 	// directions)
 	newDirection := int((angle / radiansPerDirection) - entityDirectionIncrement)
 
-	if newDirection >= 64 {
-		return newDirection - 64
-	}
-
-	if newDirection < 0 {
-		return 64 + newDirection
-	}
-
-	return newDirection
+	return d2math.WrapInt(newDirection, int(entityDirectionCount))
 }

--- a/d2common/d2math/d2vector/position_test.go
+++ b/d2common/d2math/d2vector/position_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestEntityPosition(t *testing.T) {
 	x, y := rand.Intn(1000), rand.Intn(1000)
-	pos := EntityPosition(x, y)
 	locX, locY := float64(x), float64(y)
+	pos := EntityPosition(locX, locY)
 
 	// old coordinate values			Position equivalent
 	locationX := locX                 // .SubWord().X()

--- a/d2common/d2math/d2vector/position_test.go
+++ b/d2common/d2math/d2vector/position_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 )
 
-func TestEntityPosition(t *testing.T) {
+func TestNewPosition(t *testing.T) {
 	x, y := rand.Intn(1000), rand.Intn(1000)
 	locX, locY := float64(x), float64(y)
-	pos := EntityPosition(locX, locY)
+	pos := NewPosition(locX, locY)
 
 	// old coordinate values			Position equivalent
 	locationX := locX                 // .SubWord().X()
@@ -30,11 +30,11 @@ func TestEntityPosition(t *testing.T) {
 	got = pos.RenderOffset()
 
 	if !got.Equals(want) {
-		t.Errorf("sub cell position should match old value: got %s: want %s", got, want)
+		t.Errorf("render offset position should match old value: got %s: want %s", got, want)
 	}
 
 	want = NewVector(locationX, locationY)
-	got = pos.WorldSubTile()
+	got = &pos.Vector
 
 	if !got.Equals(want) {
 		t.Errorf("sub tile position should match old value: got %s: want %s", got, want)
@@ -51,47 +51,29 @@ func validate(description string, t *testing.T, original, got, want, unchanged V
 	}
 }
 
-func TestTile(t *testing.T) {
-	p := NewPosition(1.6, 1.6)
+func TestPosition_World(t *testing.T) {
+	p := NewPosition(5, 10)
+	unchanged := p.Clone()
+	got := p.World()
+	want := NewVector(1, 2)
+
+	validate("world position", t, p.Vector, *got, want, unchanged)
+}
+
+func TestPosition_Tile(t *testing.T) {
+	p := NewPosition(23, 24)
+	unchanged := p.Clone()
 	got := p.Tile()
-	want := NewVector(1, 1)
-	unchanged := NewVector(1.6, 1.6)
+	want := NewVector(4, 4)
 
 	validate("tile position", t, p.Vector, *got, want, unchanged)
 }
 
-func TestTileOffset(t *testing.T) {
-	p := NewPosition(1.6, 1.6)
-	got := p.TileOffset()
-	want := NewVector(0.6, 0.6)
-	unchanged := NewVector(1.6, 1.6)
-
-	validate("tile offset", t, p.Vector, *got, want, unchanged)
-}
-
-func TestSubWorld(t *testing.T) {
-	p := NewPosition(1, 1)
-	got := p.WorldSubTile()
-	want := NewVector(5, 5)
-	unchanged := NewVector(1, 1)
-
-	validate("sub tile world position", t, p.Vector, *got, want, unchanged)
-}
-
-func TestSubTile(t *testing.T) {
-	p := NewPosition(1, 1)
-	got := p.TileSubTile()
-	want := NewVector(5, 5)
-	unchanged := NewVector(1, 1)
-
-	validate("sub tile with offset", t, p.Vector, *got, want, unchanged)
-}
-
-func TestRenderOffset(t *testing.T) {
-	p := NewPosition(1.1, 1.1)
-	got := p.SubTileOffset()
-	want := NewVector(0.5, 0.5)
-	unchanged := NewVector(1.1, 1.1)
+func TestPosition_RenderOffset(t *testing.T) {
+	p := NewPosition(12.1, 14.2)
+	unchanged := p.Clone()
+	got := p.RenderOffset()
+	want := NewVector(3.1, 5.2)
 
 	validate("offset from sub tile", t, p.Vector, *got, want, unchanged)
 }

--- a/d2common/d2math/d2vector/position_test.go
+++ b/d2common/d2math/d2vector/position_test.go
@@ -34,7 +34,7 @@ func TestEntityPosition(t *testing.T) {
 	}
 
 	want = NewVector(locationX, locationY)
-	got = pos.SubWorld()
+	got = pos.WorldSubTile()
 
 	if !got.Equals(want) {
 		t.Errorf("sub tile position should match old value: got %s: want %s", got, want)
@@ -71,7 +71,7 @@ func TestTileOffset(t *testing.T) {
 
 func TestSubWorld(t *testing.T) {
 	p := NewPosition(1, 1)
-	got := p.SubWorld()
+	got := p.WorldSubTile()
 	want := NewVector(5, 5)
 	unchanged := NewVector(1, 1)
 
@@ -80,7 +80,7 @@ func TestSubWorld(t *testing.T) {
 
 func TestSubTile(t *testing.T) {
 	p := NewPosition(1, 1)
-	got := p.SubTile()
+	got := p.TileSubTile()
 	want := NewVector(5, 5)
 	unchanged := NewVector(1, 1)
 

--- a/d2common/d2math/d2vector/position_test.go
+++ b/d2common/d2math/d2vector/position_test.go
@@ -16,8 +16,8 @@ func TestEntityPosition(t *testing.T) {
 	locationY := locY                 // .SubWord().Y()
 	tileX := float64(x / 5)           // .Tile().X()
 	tileY := float64(y / 5)           // .Tile().Y()
-	subcellX := 1 + math.Mod(locX, 5) // .SubCell().X()
-	subcellY := 1 + math.Mod(locY, 5) // .SubCell().Y()
+	subcellX := 1 + math.Mod(locX, 5) // .RenderOffset().X()
+	subcellY := 1 + math.Mod(locY, 5) // .RenderOffset().Y()
 
 	want := NewVector(tileX, tileY)
 	got := pos.Tile()
@@ -27,7 +27,7 @@ func TestEntityPosition(t *testing.T) {
 	}
 
 	want = NewVector(subcellX, subcellY)
-	got = pos.SubCell()
+	got = pos.RenderOffset()
 
 	if !got.Equals(want) {
 		t.Errorf("sub cell position should match old value: got %s: want %s", got, want)
@@ -87,7 +87,7 @@ func TestSubTile(t *testing.T) {
 	validate("sub tile with offset", t, p.Vector, *got, want, unchanged)
 }
 
-func TestSubTileOffset(t *testing.T) {
+func TestRenderOffset(t *testing.T) {
 	p := NewPosition(1.1, 1.1)
 	got := p.SubTileOffset()
 	want := NewVector(0.5, 0.5)

--- a/d2common/d2math/d2vector/vector.go
+++ b/d2common/d2math/d2vector/vector.go
@@ -13,7 +13,10 @@ type Vector struct {
 	x, y float64
 }
 
-const two float64 = 2
+const (
+	two                  float64 = 2
+	entityDirectionCount float64 = 64 // 64 is the diablo equivalent of 360 degrees when dealing with entity rotation.
+)
 
 // NewVector creates a new Vector with the given x and y values.
 func NewVector(x, y float64) Vector {
@@ -238,6 +241,10 @@ func (v *Vector) Normalize() float64 {
 // Angle computes the unsigned angle in radians from this vector to the given vector. This angle will never exceed half
 // a full circle. For angles describing a full circumference use SignedAngle.
 func (v *Vector) Angle(o Vector) float64 {
+	if v.IsZero() || o.IsZero() {
+		return 0
+	}
+
 	from := v.Clone()
 	from.Normalize()
 
@@ -260,6 +267,23 @@ func (v *Vector) SignedAngle(o Vector) float64 {
 	}
 
 	return unsigned
+}
+
+// TODO: Move this to Position and take a target argument, call it "DirectionTo"
+// Direction returns the anti-clockwise angle looking from this vector to the given vector. Positive X is zero.
+func (v *Vector) Direction() float64 {
+	angle := v.SignedAngle(VectorRight())
+	radiansPerDirection := d2math.RadFull / entityDirectionCount
+	offset := (45 / d2math.RadToDeg) - (radiansPerDirection / 2)
+	newDirection := (angle - offset) / radiansPerDirection
+
+	if newDirection >= 64 {
+		newDirection = newDirection - 64
+	} else if newDirection < 0 {
+		newDirection = 64 + newDirection
+	}
+
+	return newDirection
 }
 
 // Reflect sets this Vector to it's reflection off a line defined by the given normal.

--- a/d2common/d2math/d2vector/vector.go
+++ b/d2common/d2math/d2vector/vector.go
@@ -49,6 +49,12 @@ func (v *Vector) CompareApprox(o Vector) (x, y int) {
 		d2math.CompareFloat64Fuzzy(v.y, o.y)
 }
 
+// TODO: untested method
+// IsZero returns true if this vector's values are both exactly zero.
+func (v *Vector) IsZero() bool {
+	return v.x == 0 && v.y == 0
+}
+
 // Set the vector values to the given float64 values.
 func (v *Vector) Set(x, y float64) *Vector {
 	v.x = x

--- a/d2common/d2math/d2vector/vector.go
+++ b/d2common/d2math/d2vector/vector.go
@@ -51,7 +51,6 @@ func (v *Vector) CompareApprox(o Vector) (x, y int) {
 		d2math.CompareFloat64Fuzzy(v.y, o.y)
 }
 
-// TODO: untested method
 // IsZero returns true if this vector's values are both exactly zero.
 func (v *Vector) IsZero() bool {
 	return v.x == 0 && v.y == 0

--- a/d2common/d2math/d2vector/vector.go
+++ b/d2common/d2math/d2vector/vector.go
@@ -14,8 +14,7 @@ type Vector struct {
 }
 
 const (
-	two                  float64 = 2
-	entityDirectionCount float64 = 64 // 64 is the diablo equivalent of 360 degrees when dealing with entity rotation.
+	two float64 = 2
 )
 
 // NewVector creates a new Vector with the given x and y values.
@@ -267,23 +266,6 @@ func (v *Vector) SignedAngle(o Vector) float64 {
 	}
 
 	return unsigned
-}
-
-// TODO: Move this to Position and take a target argument, call it "DirectionTo"
-// Direction returns the anti-clockwise angle looking from this vector to the given vector. Positive X is zero.
-func (v *Vector) Direction() float64 {
-	angle := v.SignedAngle(VectorRight())
-	radiansPerDirection := d2math.RadFull / entityDirectionCount
-	offset := (45 / d2math.RadToDeg) - (radiansPerDirection / 2)
-	newDirection := (angle - offset) / radiansPerDirection
-
-	if newDirection >= 64 {
-		newDirection = newDirection - 64
-	} else if newDirection < 0 {
-		newDirection = 64 + newDirection
-	}
-
-	return newDirection
 }
 
 // Reflect sets this Vector to it's reflection off a line defined by the given normal.

--- a/d2common/d2math/d2vector/vector.go
+++ b/d2common/d2math/d2vector/vector.go
@@ -219,6 +219,10 @@ func (v *Vector) Cross(o Vector) float64 {
 // Normalize sets the vector length to 1 without changing the direction. The normalized vector may be scaled by the
 // float64 return value to restore it's original length.
 func (v *Vector) Normalize() float64 {
+	if v.x == 0 && v.y == 0 {
+		return 0
+	}
+
 	multiplier := 1 / v.Length()
 	v.Scale(multiplier)
 

--- a/d2common/d2math/d2vector/vector.go
+++ b/d2common/d2math/d2vector/vector.go
@@ -13,9 +13,7 @@ type Vector struct {
 	x, y float64
 }
 
-const (
-	two float64 = 2
-)
+const two float64 = 2
 
 // NewVector creates a new Vector with the given x and y values.
 func NewVector(x, y float64) Vector {
@@ -102,7 +100,7 @@ func (v *Vector) Add(o *Vector) *Vector {
 	return v
 }
 
-// AddScalar the given vector to this vector.
+// AddScalar the given value to both values of this vector.
 func (v *Vector) AddScalar(s float64) *Vector {
 	v.x += s
 	v.y += s
@@ -142,7 +140,7 @@ func (v *Vector) Divide(o *Vector) *Vector {
 	return v
 }
 
-// DivideScalar divides this vector by the given float64 value.
+// DivideScalar divides both values of this vector by the given value.
 func (v *Vector) DivideScalar(s float64) *Vector {
 	v.x /= s
 	v.y /= s
@@ -226,7 +224,7 @@ func (v *Vector) Cross(o Vector) float64 {
 // Normalize sets the vector length to 1 without changing the direction. The normalized vector may be scaled by the
 // float64 return value to restore it's original length.
 func (v *Vector) Normalize() float64 {
-	if v.x == 0 && v.y == 0 {
+	if v.IsZero() {
 		return 0
 	}
 

--- a/d2common/d2math/d2vector/vector_test.go
+++ b/d2common/d2math/d2vector/vector_test.go
@@ -333,10 +333,16 @@ func TestNormalize(t *testing.T) {
 	evaluateVector(fmt.Sprintf("normalize %s", c), want, v, t)
 
 	want = NewVector(0, 10)
-
 	v.Scale(reverse)
 
 	evaluateVector(fmt.Sprintf("reverse normalizing of %s", c), want, v, t)
+
+	v = NewVector(0, 0)
+	c = v.Clone()
+	want = NewVector(0, 0)
+	v.Normalize()
+
+	evaluateVector(fmt.Sprintf("normalize zero vector should do nothing %s", c), want, v, t)
 }
 
 func TestAngle(t *testing.T) {

--- a/d2common/d2math/d2vector/vector_test.go
+++ b/d2common/d2math/d2vector/vector_test.go
@@ -77,7 +77,7 @@ func TestEqualsF(t *testing.T) {
 	}
 }
 
-func TestCompareF(t *testing.T) {
+func TestCompareApprox(t *testing.T) {
 	subEpsilon := d2math.Epsilon / 3
 
 	f := NewVector(1+subEpsilon, 1+subEpsilon)
@@ -105,6 +105,20 @@ func TestCompareF(t *testing.T) {
 
 	if xGot != xWant || yGot != yWant {
 		t.Errorf("approximate comparison %s and %s: wanted (%d, %d): got (%d, %d)", f, c, xWant, yWant, xGot, yGot)
+	}
+}
+
+func TestIsZero(t *testing.T) {
+	testIsZero(NewVector(0, 0), true, t)
+	testIsZero(NewVector(1, 0), false, t)
+	testIsZero(NewVector(0, 1), false, t)
+	testIsZero(NewVector(1, 1), false, t)
+}
+
+func testIsZero(v Vector, want bool, t *testing.T) {
+	got := v.IsZero()
+	if got != want {
+		t.Errorf("%s is zero: want %t: got %t", v, want, got)
 	}
 }
 

--- a/d2common/d2math/d2vector/vector_test.go
+++ b/d2common/d2math/d2vector/vector_test.go
@@ -347,6 +347,7 @@ func TestNormalize(t *testing.T) {
 	evaluateVector(fmt.Sprintf("normalize %s", c), want, v, t)
 
 	want = NewVector(0, 10)
+
 	v.Scale(reverse)
 
 	evaluateVector(fmt.Sprintf("reverse normalizing of %s", c), want, v, t)
@@ -354,6 +355,7 @@ func TestNormalize(t *testing.T) {
 	v = NewVector(0, 0)
 	c = v.Clone()
 	want = NewVector(0, 0)
+
 	v.Normalize()
 
 	evaluateVector(fmt.Sprintf("normalize zero vector should do nothing %s", c), want, v, t)

--- a/d2common/d2math/doc.go
+++ b/d2common/d2math/doc.go
@@ -1,2 +1,2 @@
-// Package d2math provides mathmatical functions not included in Golang's standard math library.
+// Package d2math provides mathematical functions not included in Golang's standard math library.
 package d2math

--- a/d2common/d2math/math.go
+++ b/d2common/d2math/math.go
@@ -14,6 +14,11 @@ const (
 	RadFull float64 = 6.283185253783088
 )
 
+// EqualsApprox returns true if the difference between a and b is less than Epsilon.
+func EqualsApprox(a, b float64) bool {
+	return math.Abs(a-b) < Epsilon
+}
+
 // CompareFloat64Fuzzy returns an integer between -1 and 1 describing
 // the comparison of floats a and b. 0 will be returned if the
 // absolute difference between a and b is less than Epsilon.

--- a/d2common/d2math/math.go
+++ b/d2common/d2math/math.go
@@ -65,3 +65,14 @@ func Lerp(a, b, x float64) float64 {
 func Unlerp(a, b, x float64) float64 {
 	return (x - a) / (b - a)
 }
+
+// WrapInt wraps x to between 0 and max. For example WrapInt(450, 360) would return 90.
+func WrapInt(x, max int) int {
+	wrapped := x % max
+
+	if wrapped < 0 {
+		return max + wrapped
+	}
+
+	return wrapped
+}

--- a/d2common/d2math/math_test.go
+++ b/d2common/d2math/math_test.go
@@ -4,6 +4,24 @@ import (
 	"testing"
 )
 
+func TestEqualsApprox(t *testing.T) {
+	subEpsilon := Epsilon / 3
+
+	a, b := 1+subEpsilon, 1.0
+	got := EqualsApprox(a, b)
+
+	if !got {
+		t.Errorf("compare %.2f and %.2f: wanted %t: got %t", a, b, true, got)
+	}
+
+	a, b = 1+Epsilon, 1.0
+	got = EqualsApprox(a, b)
+
+	if !got {
+		t.Errorf("compare %.2f and %.2f: wanted %t: got %t", a, b, false, got)
+	}
+}
+
 func TestCompareFloat64Fuzzy(t *testing.T) {
 	subEpsilon := Epsilon / 3
 

--- a/d2common/d2math/math_test.go
+++ b/d2common/d2math/math_test.go
@@ -111,3 +111,39 @@ func TestUnlerp(t *testing.T) {
 		t.Errorf(d, x, a, b, want, got)
 	}
 }
+
+func TestWrapInt(t *testing.T) {
+	want := 50
+	a, b := 1050, 100
+	got := WrapInt(a, b)
+
+	d := "wrap %d between 0 and %d: want %d: got %d"
+
+	if got != want {
+		t.Errorf(d, a, b, want, got)
+	}
+
+	want = 270
+	a, b = -1170, 360
+	got = WrapInt(a, b)
+
+	if got != want {
+		t.Errorf(d, a, b, want, got)
+	}
+
+	want = 270
+	a, b = 270, 360
+	got = WrapInt(a, b)
+
+	if got != want {
+		t.Errorf(d, a, b, want, got)
+	}
+
+	want = 90
+	a, b = -270, 360
+	got = WrapInt(a, b)
+
+	if got != want {
+		t.Errorf(d, a, b, want, got)
+	}
+}

--- a/d2common/math.go
+++ b/d2common/math.go
@@ -85,34 +85,3 @@ func GetRadiansBetween(p1X, p1Y, p2X, p2Y float64) float64 {
 func AlmostEqual(a, b, threshold float64) bool {
 	return math.Abs(a-b) <= threshold
 }
-
-// AdjustWithRemainder returns the new adjusted value, as well as any remaining amount after the max
-func AdjustWithRemainder(sourceValue, adjustment, targetvalue float64) (newValue, remainder float64) {
-	if adjustment == 0 || math.Abs(adjustment) < 0.000001 {
-		return sourceValue, 0
-	}
-
-	adjustNegative := adjustment < 0.0
-	maxNegative := targetvalue-sourceValue < 0.0
-
-	if adjustNegative != maxNegative {
-		// FIXME: This shouldn't happen but it happens all the time..
-		return sourceValue, 0
-	}
-
-	finalValue := sourceValue + adjustment
-	if !adjustNegative {
-		if finalValue > targetvalue {
-			diff := finalValue - targetvalue
-			return targetvalue, diff
-		}
-
-		return finalValue, 0
-	}
-
-	if finalValue < targetvalue {
-		return targetvalue, finalValue - targetvalue
-	}
-
-	return finalValue, 0
-}

--- a/d2common/math.go
+++ b/d2common/math.go
@@ -73,25 +73,6 @@ func MinInt32(a, b int32) int32 {
 
 // ScreenToIso converts screenspace coordinates to isometric coordinates
 
-// GetAngleBetween returns the angle between two points. 0deg is facing to the right.
-func GetAngleBetween(p1X, p1Y, p2X, p2Y float64) int {
-	deltaY := p1Y - p2Y
-	deltaX := p2X - p1X
-
-	result := math.Atan2(deltaY, deltaX) * (180 / math.Pi)
-	iResult := int(result)
-
-	for iResult < 0 {
-		iResult += 360
-	}
-
-	for iResult >= 360 {
-		iResult -= 360
-	}
-
-	return iResult
-}
-
 // GetRadiansBetween returns the radians between two points. 0rad is facing to the right.
 func GetRadiansBetween(p1X, p1Y, p2X, p2Y float64) float64 {
 	deltaY := p2Y - p1Y

--- a/d2core/d2map/d2mapentity/animated_entity.go
+++ b/d2core/d2map/d2mapentity/animated_entity.go
@@ -27,10 +27,10 @@ func CreateAnimatedEntity(x, y int, animation d2interface.Animation) *AnimatedEn
 
 // Render draws this animated entity onto the target
 func (ae *AnimatedEntity) Render(target d2interface.Surface) {
-	subCellPosition := ae.Position.RenderOffset()
+	renderOffset := ae.Position.RenderOffset()
 	target.PushTranslation(
-		int((subCellPosition.X()-subCellPosition.Y())*16),
-		int(((subCellPosition.X()+subCellPosition.Y())*8)-5),
+		int((renderOffset.X()-renderOffset.Y())*16),
+		int(((renderOffset.X()+renderOffset.Y())*8)-5),
 	)
 
 	defer target.Pop()

--- a/d2core/d2map/d2mapentity/animated_entity.go
+++ b/d2core/d2map/d2mapentity/animated_entity.go
@@ -27,7 +27,7 @@ func CreateAnimatedEntity(x, y int, animation d2interface.Animation) *AnimatedEn
 
 // Render draws this animated entity onto the target
 func (ae *AnimatedEntity) Render(target d2interface.Surface) {
-	subCellPosition := ae.Position.SubCell()
+	subCellPosition := ae.Position.RenderOffset()
 	target.PushTranslation(
 		int((subCellPosition.X()-subCellPosition.Y())*16),
 		int(((subCellPosition.X()+subCellPosition.Y())*8)-5),

--- a/d2core/d2map/d2mapentity/animated_entity.go
+++ b/d2core/d2map/d2mapentity/animated_entity.go
@@ -27,10 +27,12 @@ func CreateAnimatedEntity(x, y int, animation d2interface.Animation) *AnimatedEn
 
 // Render draws this animated entity onto the target
 func (ae *AnimatedEntity) Render(target d2interface.Surface) {
+	subCellPosition := ae.Position.SubCell()
 	target.PushTranslation(
-		ae.offsetX+int((ae.subcellX-ae.subcellY)*16),
-		ae.offsetY+int(((ae.subcellX+ae.subcellY)*8)-5),
+		int((subCellPosition.X()-subCellPosition.Y())*16),
+		int(((subCellPosition.X()+subCellPosition.Y())*8)-5),
 	)
+
 	defer target.Pop()
 	ae.animation.Render(target)
 }

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -1,9 +1,6 @@
 package d2mapentity
 
 import (
-	"fmt"
-	"math"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2math"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2math/d2vector"
@@ -18,10 +15,10 @@ type mapEntity struct {
 	Position d2vector.Position
 	Target   d2vector.Position
 
-	subcellX, subcellY float64 // Subcell coordinates within the current tile
-	offsetX, offsetY   int
-	TargetX            float64
-	TargetY            float64
+	//subcellX, subcellY float64 // Subcell coordinates within the current tile
+	offsetX, offsetY int
+	TargetX          float64
+	TargetY          float64
 
 	Speed     float64
 	path      []d2astar.Pather
@@ -43,17 +40,10 @@ func createMapEntity(x, y int) mapEntity {
 		Target:    d2vector.EntityPosition(locX, locY),
 		TargetX:   locX,
 		TargetY:   locY,
-		subcellX:  1 + math.Mod(locX, 5),
-		subcellY:  1 + math.Mod(locY, 5),
 		Speed:     6,
 		drawLayer: 0,
 		path:      []d2astar.Pather{},
 	}
-}
-
-func (m mapEntity) String() string {
-	return fmt.Sprintf("subcellXY: %.2f, %.2f\nTargetXY: %.2f, %.2f", // TileXY: %d, %d
-		m.subcellX, m.subcellY, m.TargetX, m.TargetY)
 }
 
 // GetLayer returns the draw layer for this entity.
@@ -139,10 +129,6 @@ func (m *mapEntity) Step(tickTime float64) {
 		step.Set(newStepX, newStepY)
 
 		position = m.Position.WorldSubTile()
-		// set the other value types
-		m.subcellX = 1 + math.Mod(position.X(), 5)
-		m.subcellY = 1 + math.Mod(position.Y(), 5)
-
 		// position is close to target
 		if d2common.AlmostEqual(position.X(), m.TargetX, 0.01) && d2common.AlmostEqual(position.Y(), m.TargetY, 0.01) {
 			// entity has a path
@@ -161,8 +147,6 @@ func (m *mapEntity) Step(tickTime float64) {
 			} else {
 				m.Position.SetSubWorld(m.TargetX, m.TargetY)
 				position = m.Position.WorldSubTile()
-				m.subcellX = 1 + math.Mod(position.X(), 5)
-				m.subcellY = 1 + math.Mod(position.Y(), 5)
 			}
 		}
 

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -18,7 +18,6 @@ type mapEntity struct {
 
 	LocationX          float64
 	LocationY          float64
-	TileX, TileY       int     // Coordinates of the tile the unit is within
 	subcellX, subcellY float64 // Subcell coordinates within the current tile
 	offsetX, offsetY   int
 	TargetX            float64
@@ -44,8 +43,6 @@ func createMapEntity(x, y int) mapEntity {
 		LocationY: locY,
 		TargetX:   locX,
 		TargetY:   locY,
-		TileX:     x / 5,
-		TileY:     y / 5,
 		subcellX:  1 + math.Mod(locX, 5),
 		subcellY:  1 + math.Mod(locY, 5),
 		Speed:     6,
@@ -55,8 +52,8 @@ func createMapEntity(x, y int) mapEntity {
 }
 
 func (m mapEntity) String() string {
-	return fmt.Sprintf("LocationXY: %.2f, %.2f\nTileXY: %d, %d\nsubcellXY: %.2f, %.2f\nTargetXY: %.2f, %.2f",
-		m.LocationX, m.LocationY, m.TileX, m.TileY, m.subcellX, m.subcellY, m.TargetX, m.TargetY)
+	return fmt.Sprintf("LocationXY: %.2f, %.2f\nsubcellXY: %.2f, %.2f\nTargetXY: %.2f, %.2f", // TileXY: %d, %d
+		m.LocationX, m.LocationY /*m.TileX, m.TileY,*/, m.subcellX, m.subcellY, m.TargetX, m.TargetY)
 }
 
 // GetLayer returns the draw layer for this entity.
@@ -137,8 +134,6 @@ func (m *mapEntity) Step(tickTime float64) {
 		// set the other value types
 		m.subcellX = 1 + math.Mod(m.LocationX, 5)
 		m.subcellY = 1 + math.Mod(m.LocationY, 5)
-		m.TileX = int(m.LocationX / 5)
-		m.TileY = int(m.LocationY / 5)
 
 		// position is close to target
 		if d2common.AlmostEqual(m.LocationX, m.TargetX, 0.01) && d2common.AlmostEqual(m.LocationY, m.TargetY, 0.01) {
@@ -160,8 +155,6 @@ func (m *mapEntity) Step(tickTime float64) {
 				m.LocationY = m.TargetY
 				m.subcellX = 1 + math.Mod(m.LocationX, 5)
 				m.subcellY = 1 + math.Mod(m.LocationY, 5)
-				m.TileX = int(m.LocationX / 5)
-				m.TileY = int(m.LocationY / 5)
 
 				// TODO: This should be the authority
 				m.SetSubWorld(m.LocationX, m.LocationY) // //
@@ -215,12 +208,14 @@ func angleToDirection(angle float64) int {
 
 // GetPosition returns the entity's current tile position.
 func (m *mapEntity) GetPosition() (float64, float64) {
-	return float64(m.TileX), float64(m.TileY)
+	t := m.Tile()
+	return t.X(), t.Y()
 }
 
 // GetPositionF returns the entity's current sub tile position.
 func (m *mapEntity) GetPositionF() (float64, float64) {
-	return float64(m.TileX) + (float64(m.subcellX) / 5.0), float64(m.TileY) + (float64(m.subcellY) / 5.0)
+	w := m.World()
+	return w.X(), w.Y()
 }
 
 // Name returns the NPC's in-game name (e.g. "Deckard Cain") or an empty string if it does not have a name

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -9,6 +9,10 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2astar"
 )
 
+const (
+	directionCount = 64
+)
+
 // mapEntity represents an entity on the map that can be animated
 // TODO: Has a coordinate (issue #456)
 type mapEntity struct {
@@ -156,31 +160,14 @@ func (m *mapEntity) SetTarget(tx, ty float64, done func()) {
 	m.Target.SetSubWorld(tx, ty)
 	m.done = done
 
-	position := m.Position.WorldSubTile()
 	if m.directioner != nil {
-		angle := 359 - d2common.GetAngleBetween(
-			position.X(),
-			position.Y(),
-			tx,
-			ty,
-		)
-		m.directioner(angleToDirection(float64(angle)))
+		direction := m.Target.Clone()
+		direction.Subtract(&m.Position.Vector)
+
+		angle := direction.Direction()
+
+		m.directioner(int(angle))
 	}
-}
-
-func angleToDirection(angle float64) int {
-	degreesPerDirection := 360.0 / 64.0
-	offset := 45.0 - (degreesPerDirection / 2)
-
-	newDirection := int((angle - offset) / degreesPerDirection)
-
-	if newDirection >= 64 {
-		newDirection = newDirection - 64
-	} else if newDirection < 0 {
-		newDirection = 64 + newDirection
-	}
-
-	return newDirection
 }
 
 // GetPosition returns the entity's current tile position.

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -39,6 +39,8 @@ func createMapEntity(x, y int) mapEntity {
 	locX, locY := float64(x), float64(y)
 
 	return mapEntity{
+		Position:  d2vector.EntityPosition(locX, locY),
+		Target:    d2vector.EntityPosition(locX, locY),
 		LocationX: locX,
 		LocationY: locY,
 		TargetX:   locX,

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -13,8 +13,8 @@ import (
 // mapEntity represents an entity on the map that can be animated
 // TODO: Has a coordinate (issue #456)
 type mapEntity struct {
-	d2vector.Position
-	Target d2vector.Position
+	Position d2vector.Position
+	Target   d2vector.Position
 
 	LocationX          float64
 	LocationY          float64
@@ -89,7 +89,7 @@ func (m *mapEntity) getStepLength(tickTime float64) (float64, float64) {
 	length := tickTime * m.Speed
 
 	vector := m.Target.SubWorld()
-	vector.Subtract(m.SubWorld())
+	vector.Subtract(m.Position.SubWorld())
 	vector.SetLength(length)
 
 	return vector.X(), vector.Y()
@@ -131,7 +131,7 @@ func (m *mapEntity) Step(tickTime float64) {
 		m.LocationY, stepY = d2common.AdjustWithRemainder(m.LocationY, stepY, m.TargetY)
 
 		// TODO: This should be the authority
-		m.SetSubWorld(m.LocationX, m.LocationY) // //
+		m.Position.SetSubWorld(m.LocationX, m.LocationY) // //
 
 		// set the other value types
 		m.subcellX = 1 + math.Mod(m.LocationX, 5)
@@ -159,7 +159,7 @@ func (m *mapEntity) Step(tickTime float64) {
 				m.subcellY = 1 + math.Mod(m.LocationY, 5)
 
 				// TODO: This should be the authority
-				m.SetSubWorld(m.LocationX, m.LocationY) // //
+				m.Position.SetSubWorld(m.LocationX, m.LocationY) // //
 			}
 		}
 
@@ -210,13 +210,13 @@ func angleToDirection(angle float64) int {
 
 // GetPosition returns the entity's current tile position.
 func (m *mapEntity) GetPosition() (float64, float64) {
-	t := m.Tile()
+	t := m.Position.Tile()
 	return t.X(), t.Y()
 }
 
 // GetPositionF returns the entity's current sub tile position.
 func (m *mapEntity) GetPositionF() (float64, float64) {
-	w := m.World()
+	w := m.Position.World()
 	return w.X(), w.Y()
 }
 

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -61,7 +61,7 @@ func (m *mapEntity) GetSpeed() float64 {
 	return m.Speed
 }
 
-// IsAtTarget returns true if the entity is within a 0.0002 square of it's target and has a path.
+// IsAtTarget returns true if the distance between entity and target is almost zero.
 func (m *mapEntity) IsAtTarget() bool {
 	return m.Position.EqualsApprox(m.Target.Vector) && !m.HasPathFinding()
 }
@@ -160,9 +160,9 @@ func (m *mapEntity) SetTarget(tx, ty float64, done func()) {
 	m.done = done
 
 	if m.directioner != nil {
-		angle := m.Position.DirectionTo(m.Target.Vector)
+		d := m.Position.DirectionTo(m.Target.Vector)
 
-		m.directioner(angle)
+		m.directioner(d)
 	}
 }
 

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -8,7 +8,6 @@ import (
 )
 
 // mapEntity represents an entity on the map that can be animated
-// TODO: Has a coordinate (issue #456)
 type mapEntity struct {
 	Position d2vector.Position
 	Target   d2vector.Position
@@ -112,6 +111,7 @@ func (m *mapEntity) velocity(tickTime float64) d2vector.Vector {
 	v := m.Target.Vector.Clone()
 	v.Subtract(&m.Position.Vector)
 	v.SetLength(length)
+
 	return v
 }
 
@@ -167,13 +167,13 @@ func (m *mapEntity) SetTarget(tx, ty float64, done func()) {
 }
 
 // GetPosition returns the entity's current tile position, always a whole number.
-func (m *mapEntity) GetPosition() (float64, float64) {
+func (m *mapEntity) GetPosition() (x, y float64) {
 	t := m.Position.Tile()
 	return t.X(), t.Y()
 }
 
 // GetPositionF returns the entity's current tile position where 0.2 is one sub tile.
-func (m *mapEntity) GetPositionF() (float64, float64) {
+func (m *mapEntity) GetPositionF() (x, y float64) {
 	w := m.Position.World()
 	return w.X(), w.Y()
 }

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -161,12 +161,9 @@ func (m *mapEntity) SetTarget(tx, ty float64, done func()) {
 	m.done = done
 
 	if m.directioner != nil {
-		direction := m.Target.Clone()
-		direction.Subtract(&m.Position.Vector)
+		angle := m.Position.DirectionTo(m.Target.Vector)
 
-		angle := direction.Direction()
-
-		m.directioner(int(angle))
+		m.directioner(angle)
 	}
 }
 

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -15,17 +15,9 @@ type mapEntity struct {
 	Position d2vector.Position
 	Target   d2vector.Position
 
-	//subcellX, subcellY float64 // Subcell coordinates within the current tile
-	offsetX, offsetY int
-	TargetX          float64
-	TargetY          float64
-
 	Speed     float64
 	path      []d2astar.Pather
 	drawLayer int
-
-	// TODO: delete this
-	debugLevel int
 
 	done        func()
 	directioner func(direction int)
@@ -38,8 +30,6 @@ func createMapEntity(x, y int) mapEntity {
 	return mapEntity{
 		Position:  d2vector.EntityPosition(locX, locY),
 		Target:    d2vector.EntityPosition(locX, locY),
-		TargetX:   locX,
-		TargetY:   locY,
 		Speed:     6,
 		drawLayer: 0,
 		path:      []d2astar.Pather{},
@@ -130,7 +120,7 @@ func (m *mapEntity) Step(tickTime float64) {
 
 		position = m.Position.WorldSubTile()
 		// position is close to target
-		if d2common.AlmostEqual(position.X(), m.TargetX, 0.01) && d2common.AlmostEqual(position.Y(), m.TargetY, 0.01) {
+		if d2common.AlmostEqual(position.X(), targetPosition.X(), 0.01) && d2common.AlmostEqual(position.Y(), targetPosition.Y(), 0.01) {
 			// entity has a path
 			if len(m.path) > 0 {
 				// set target as next node in path
@@ -145,7 +135,7 @@ func (m *mapEntity) Step(tickTime float64) {
 				// entity had no path
 				// set location to target
 			} else {
-				m.Position.SetSubWorld(m.TargetX, m.TargetY)
+				m.Position.Copy(&m.Target.Vector)
 				position = m.Position.WorldSubTile()
 			}
 		}
@@ -163,11 +153,8 @@ func (m *mapEntity) HasPathFinding() bool {
 
 // SetTarget sets target coordinates and changes animation based on proximity and direction.
 func (m *mapEntity) SetTarget(tx, ty float64, done func()) {
-	m.TargetX, m.TargetY = tx, ty
-	m.done = done
-
-	// TODO: This should be the authority
 	m.Target.SetSubWorld(tx, ty)
+	m.done = done
 
 	position := m.Position.WorldSubTile()
 	if m.directioner != nil {

--- a/d2core/d2map/d2mapentity/missile.go
+++ b/d2core/d2map/d2mapentity/missile.go
@@ -51,9 +51,8 @@ func CreateMissile(x, y int, record *d2datadict.MissileRecord) (*Missile, error)
 func (m *Missile) SetRadians(angle float64, done func()) {
 	r := float64(m.record.Range)
 
-	subTilePosition := m.Position.WorldSubTile()
-	x := subTilePosition.X() + (r * math.Cos(angle))
-	y := subTilePosition.Y() + (r * math.Sin(angle))
+	x := m.Position.X() + (r * math.Cos(angle))
+	y := m.Position.Y() + (r * math.Sin(angle))
 
 	m.SetTarget(x, y, done)
 }

--- a/d2core/d2map/d2mapentity/missile.go
+++ b/d2core/d2map/d2mapentity/missile.go
@@ -51,8 +51,9 @@ func CreateMissile(x, y int, record *d2datadict.MissileRecord) (*Missile, error)
 func (m *Missile) SetRadians(angle float64, done func()) {
 	r := float64(m.record.Range)
 
-	x := m.LocationX + (r * math.Cos(angle))
-	y := m.LocationY + (r * math.Sin(angle))
+	subTilePosition := m.Position.SubWorld()
+	x := subTilePosition.X() + (r * math.Cos(angle))
+	y := subTilePosition.Y() + (r * math.Sin(angle))
 
 	m.SetTarget(x, y, done)
 }

--- a/d2core/d2map/d2mapentity/missile.go
+++ b/d2core/d2map/d2mapentity/missile.go
@@ -32,7 +32,7 @@ func CreateMissile(x, y int, record *d2datadict.MissileRecord) (*Missile, error)
 	}
 
 	animation.SetEffect(d2enum.DrawEffectModulate)
-	//animation.SetPlaySpeed(float64(record.Animation.AnimationSpeed))
+	// animation.SetPlaySpeed(float64(record.Animation.AnimationSpeed))
 	animation.SetPlayLoop(record.Animation.LoopAnimation)
 	animation.PlayForward()
 	entity := CreateAnimatedEntity(x, y, animation)

--- a/d2core/d2map/d2mapentity/missile.go
+++ b/d2core/d2map/d2mapentity/missile.go
@@ -51,7 +51,7 @@ func CreateMissile(x, y int, record *d2datadict.MissileRecord) (*Missile, error)
 func (m *Missile) SetRadians(angle float64, done func()) {
 	r := float64(m.record.Range)
 
-	subTilePosition := m.Position.SubWorld()
+	subTilePosition := m.Position.WorldSubTile()
 	x := subTilePosition.X() + (r * math.Cos(angle))
 	y := subTilePosition.Y() + (r * math.Sin(angle))
 

--- a/d2core/d2map/d2mapentity/npc.go
+++ b/d2core/d2map/d2mapentity/npc.go
@@ -72,10 +72,10 @@ func selectEquip(slice []string) string {
 
 // Render renders this entity's animated composite.
 func (v *NPC) Render(target d2interface.Surface) {
-	subCellPosition := v.Position.RenderOffset()
+	renderOffset := v.Position.RenderOffset()
 	target.PushTranslation(
-		int((subCellPosition.X()-subCellPosition.Y())*16),
-		int(((subCellPosition.X()+subCellPosition.Y())*8)-5),
+		int((renderOffset.X()-renderOffset.Y())*16),
+		int(((renderOffset.X()+renderOffset.Y())*8)-5),
 	)
 
 	defer target.Pop()

--- a/d2core/d2map/d2mapentity/npc.go
+++ b/d2core/d2map/d2mapentity/npc.go
@@ -72,10 +72,12 @@ func selectEquip(slice []string) string {
 
 // Render renders this entity's animated composite.
 func (v *NPC) Render(target d2interface.Surface) {
+	subCellPosition := v.Position.SubCell()
 	target.PushTranslation(
-		v.offsetX+int((v.subcellX-v.subcellY)*16),
-		v.offsetY+int(((v.subcellX+v.subcellY)*8)-5),
+		int((subCellPosition.X()-subCellPosition.Y())*16),
+		int(((subCellPosition.X()+subCellPosition.Y())*8)-5),
 	)
+
 	defer target.Pop()
 	v.composite.Render(target)
 }

--- a/d2core/d2map/d2mapentity/npc.go
+++ b/d2core/d2map/d2mapentity/npc.go
@@ -72,7 +72,7 @@ func selectEquip(slice []string) string {
 
 // Render renders this entity's animated composite.
 func (v *NPC) Render(target d2interface.Surface) {
-	subCellPosition := v.Position.SubCell()
+	subCellPosition := v.Position.RenderOffset()
 	target.PushTranslation(
 		int((subCellPosition.X()-subCellPosition.Y())*16),
 		int(((subCellPosition.X()+subCellPosition.Y())*8)-5),

--- a/d2core/d2map/d2mapentity/player.go
+++ b/d2core/d2map/d2mapentity/player.go
@@ -182,6 +182,7 @@ func (v *Player) GetAnimationMode() d2enum.PlayerAnimationMode {
 	return d2enum.PlayerAnimationModeNeutral
 }
 
+// SetAnimationMode sets the Composite's animation mode weapon class and direction.
 func (v *Player) SetAnimationMode(animationMode d2enum.PlayerAnimationMode) error {
 	return v.composite.SetMode(animationMode, v.composite.GetWeaponClass())
 }

--- a/d2core/d2map/d2mapentity/player.go
+++ b/d2core/d2map/d2mapentity/player.go
@@ -144,10 +144,10 @@ func (v *Player) Advance(tickTime float64) {
 
 // Render renders the animated composite for this entity.
 func (v *Player) Render(target d2interface.Surface) {
-	subCellPosition := v.Position.RenderOffset()
+	renderOffset := v.Position.RenderOffset()
 	target.PushTranslation(
-		int((subCellPosition.X()-subCellPosition.Y())*16),
-		int(((subCellPosition.X()+subCellPosition.Y())*8)-5),
+		int((renderOffset.X()-renderOffset.Y())*16),
+		int(((renderOffset.X()+renderOffset.Y())*8)-5),
 	)
 
 	defer target.Pop()

--- a/d2core/d2map/d2mapentity/player.go
+++ b/d2core/d2map/d2mapentity/player.go
@@ -144,7 +144,7 @@ func (v *Player) Advance(tickTime float64) {
 
 // Render renders the animated composite for this entity.
 func (v *Player) Render(target d2interface.Surface) {
-	subCellPosition := v.Position.SubCell()
+	subCellPosition := v.Position.RenderOffset()
 	target.PushTranslation(
 		int((subCellPosition.X()-subCellPosition.Y())*16),
 		int(((subCellPosition.X()+subCellPosition.Y())*8)-5),

--- a/d2core/d2map/d2mapentity/player.go
+++ b/d2core/d2map/d2mapentity/player.go
@@ -144,10 +144,12 @@ func (v *Player) Advance(tickTime float64) {
 
 // Render renders the animated composite for this entity.
 func (v *Player) Render(target d2interface.Surface) {
+	subCellPosition := v.Position.SubCell()
 	target.PushTranslation(
-		v.offsetX+int((v.subcellX-v.subcellY)*16),
-		v.offsetY+int(((v.subcellX+v.subcellY)*8)-5),
+		int((subCellPosition.X()-subCellPosition.Y())*16),
+		int(((subCellPosition.X()+subCellPosition.Y())*8)-5),
 	)
+
 	defer target.Pop()
 	v.composite.Render(target)
 	// v.nameLabel.X = v.offsetX

--- a/d2game/d2gamescreen/game.go
+++ b/d2game/d2gamescreen/game.go
@@ -144,7 +144,8 @@ func (v *Game) Advance(tickTime float64) error {
 
 	// Update the camera to focus on the player
 	if v.localPlayer != nil && !v.gameControls.FreeCam {
-		rx, ry := v.mapRenderer.WorldToOrtho(v.localPlayer.LocationX/5, v.localPlayer.LocationY/5)
+		worldPosition := v.localPlayer.Position.World()
+		rx, ry := v.mapRenderer.WorldToOrtho(worldPosition.X(), worldPosition.Y())
 		v.mapRenderer.MoveCameraTo(rx, ry)
 	}
 
@@ -171,10 +172,9 @@ func (v *Game) bindGameControls() {
 
 // OnPlayerMove sends the player move action to the server
 func (v *Game) OnPlayerMove(x, y float64) {
-	heroPosX := v.localPlayer.LocationX / 5.0
-	heroPosY := v.localPlayer.LocationY / 5.0
+	worldPosition := v.localPlayer.Position.World()
 
-	err := v.gameClient.SendPacketToServer(d2netpacket.CreateMovePlayerPacket(v.gameClient.PlayerId, heroPosX, heroPosY, x, y))
+	err := v.gameClient.SendPacketToServer(d2netpacket.CreateMovePlayerPacket(v.gameClient.PlayerId, worldPosition.X(), worldPosition.Y(), x, y))
 	if err != nil {
 		fmt.Printf("failed to send MovePlayer packet to the server, playerId: %s, x: %g, x: %g\n", v.gameClient.PlayerId, x, y)
 	}

--- a/d2game/d2gamescreen/game.go
+++ b/d2game/d2gamescreen/game.go
@@ -117,7 +117,9 @@ func (v *Game) Advance(tickTime float64) error {
 	if v.ticksSinceLevelCheck > 1.0 {
 		v.ticksSinceLevelCheck = 0
 		if v.localPlayer != nil {
-			tile := v.gameClient.MapEngine.TileAt(v.localPlayer.TileX, v.localPlayer.TileY)
+			// TODO: implement vector in TileAt
+			tilePosition := v.localPlayer.Position.Tile()
+			tile := v.gameClient.MapEngine.TileAt(int(tilePosition.X()), int(tilePosition.Y()))
 			if tile != nil {
 				musicInfo := d2common.GetMusicDef(tile.RegionType)
 				v.audioProvider.PlayBGM(musicInfo.MusicFile)

--- a/d2game/d2gamescreen/game.go
+++ b/d2game/d2gamescreen/game.go
@@ -117,9 +117,9 @@ func (v *Game) Advance(tickTime float64) error {
 	if v.ticksSinceLevelCheck > 1.0 {
 		v.ticksSinceLevelCheck = 0
 		if v.localPlayer != nil {
-			// TODO: implement vector in TileAt
 			tilePosition := v.localPlayer.Position.Tile()
 			tile := v.gameClient.MapEngine.TileAt(int(tilePosition.X()), int(tilePosition.Y()))
+
 			if tile != nil {
 				musicInfo := d2common.GetMusicDef(tile.RegionType)
 				v.audioProvider.PlayBGM(musicInfo.MusicFile)

--- a/d2networking/d2client/game_client.go
+++ b/d2networking/d2client/game_client.go
@@ -136,10 +136,9 @@ func (g *GameClient) OnPacketReceived(packet d2netpacket.NetPacket) error {
 		player.SetCasting()
 		player.ClearPath()
 		// currently hardcoded to missile skill
-		subTilePosition := player.Position.WorldSubTile()
 		missile, err := d2mapentity.CreateMissile(
-			int(subTilePosition.X()),
-			int(subTilePosition.Y()),
+			int(player.Position.X()),
+			int(player.Position.Y()),
 			d2datadict.Missiles[playerCast.SkillID],
 		)
 		if err != nil {
@@ -147,8 +146,8 @@ func (g *GameClient) OnPacketReceived(packet d2netpacket.NetPacket) error {
 		}
 
 		rads := d2common.GetRadiansBetween(
-			subTilePosition.X(),
-			subTilePosition.Y(),
+			player.Position.X(),
+			player.Position.Y(),
 			playerCast.TargetX*5,
 			playerCast.TargetY*5,
 		)

--- a/d2networking/d2client/game_client.go
+++ b/d2networking/d2client/game_client.go
@@ -111,7 +111,6 @@ func (g *GameClient) OnPacketReceived(packet d2netpacket.NetPacket) error {
 		path, _, _ := g.MapEngine.PathFind(movePlayer.StartX, movePlayer.StartY, movePlayer.DestX, movePlayer.DestY)
 		if len(path) > 0 {
 			player.SetPath(path, func() {
-				// TODO: implement vector in TileAt
 				tilePosition := player.Position.Tile()
 				tile := g.MapEngine.TileAt(int(tilePosition.X()), int(tilePosition.Y()))
 				if tile == nil {

--- a/d2networking/d2client/game_client.go
+++ b/d2networking/d2client/game_client.go
@@ -136,9 +136,10 @@ func (g *GameClient) OnPacketReceived(packet d2netpacket.NetPacket) error {
 		player.SetCasting()
 		player.ClearPath()
 		// currently hardcoded to missile skill
+		subTilePosition := player.Position.SubWorld()
 		missile, err := d2mapentity.CreateMissile(
-			int(player.LocationX),
-			int(player.LocationY),
+			int(subTilePosition.X()),
+			int(subTilePosition.Y()),
 			d2datadict.Missiles[playerCast.SkillID],
 		)
 		if err != nil {
@@ -146,8 +147,8 @@ func (g *GameClient) OnPacketReceived(packet d2netpacket.NetPacket) error {
 		}
 
 		rads := d2common.GetRadiansBetween(
-			player.LocationX,
-			player.LocationY,
+			subTilePosition.X(),
+			subTilePosition.Y(),
 			playerCast.TargetX*5,
 			playerCast.TargetY*5,
 		)

--- a/d2networking/d2client/game_client.go
+++ b/d2networking/d2client/game_client.go
@@ -136,7 +136,7 @@ func (g *GameClient) OnPacketReceived(packet d2netpacket.NetPacket) error {
 		player.SetCasting()
 		player.ClearPath()
 		// currently hardcoded to missile skill
-		subTilePosition := player.Position.SubWorld()
+		subTilePosition := player.Position.WorldSubTile()
 		missile, err := d2mapentity.CreateMissile(
 			int(subTilePosition.X()),
 			int(subTilePosition.Y()),

--- a/d2networking/d2client/game_client.go
+++ b/d2networking/d2client/game_client.go
@@ -111,7 +111,9 @@ func (g *GameClient) OnPacketReceived(packet d2netpacket.NetPacket) error {
 		path, _, _ := g.MapEngine.PathFind(movePlayer.StartX, movePlayer.StartY, movePlayer.DestX, movePlayer.DestY)
 		if len(path) > 0 {
 			player.SetPath(path, func() {
-				tile := g.MapEngine.TileAt(player.TileX, player.TileY)
+				// TODO: implement vector in TileAt
+				tilePosition := player.Position.Tile()
+				tile := g.MapEngine.TileAt(int(tilePosition.X()), int(tilePosition.Y()))
 				if tile == nil {
 					return
 				}


### PR DESCRIPTION
This PR implements `d2vector.Position` and `d2vector.Vector` in `mapEntity`. Apologies for the size, I tried to keep it small.

Most of the maths used in `mapEntity.Step()` has been completely replaced with the new `Vector` methods. I was careful to ensure parity before migrating from the old systems, so everything should still work as it did before.

There is more work to do here, hopefully this is a solid start.

Next up (probably)

* Profiling, testing and optimising `Position` and `mapEntity`.
* Review and consolidate the other types in `d2mapentity`.
* _something about map generation_