### PR TITLE
Add static checks to help ensure struct implementations conform to interfaces

### DIFF
--- a/d2common/bitmuncher.go
+++ b/d2common/bitmuncher.go
@@ -2,6 +2,8 @@ package d2common
 
 import "github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 
+var _ d2interface.BitMuncher = &BitMuncher{} // Static check to confirm struct conforms to interface
+
 // BitMuncher is used for parsing files that are not byte-aligned such as the DCC files.
 type BitMuncher struct {
 	data     []byte

--- a/d2common/bitstream.go
+++ b/d2common/bitstream.go
@@ -1,6 +1,12 @@
 package d2common
 
-import "log"
+import (
+	"log"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
+)
+
+var _ d2interface.BitStream = &BitStream{} // Static check to confirm struct conforms to interface
 
 // BitStream is a utility class for reading groups of bits from a stream
 type BitStream struct {

--- a/d2common/cache.go
+++ b/d2common/cache.go
@@ -8,6 +8,8 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
 
+var _ d2interface.Cache = &Cache{} // Static check to confirm struct conforms to interface
+
 type cacheNode struct {
 	next   *cacheNode
 	prev   *cacheNode

--- a/d2common/d2fileformats/d2mpq/mpq.go
+++ b/d2common/d2fileformats/d2mpq/mpq.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/binary"
 	"errors"
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"io/ioutil"
 	"log"
 	"os"
@@ -12,7 +11,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
+
+var _ d2interface.Archive = &MPQ{} // Static check to confirm struct conforms to interface
 
 // MPQ represents an MPQ archive
 type MPQ struct {

--- a/d2common/d2fileformats/d2mpq/mpq_data_stream.go
+++ b/d2common/d2fileformats/d2mpq/mpq_data_stream.go
@@ -1,5 +1,9 @@
 package d2mpq
 
+import "github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
+
+var _ d2interface.ArchiveDataStream = &MpqDataStream{} // Static check to confirm struct conforms to interface
+
 // MpqDataStream represents a stream for MPQ data.
 type MpqDataStream struct {
 	stream *Stream

--- a/d2core/d2asset/animation_manager.go
+++ b/d2core/d2asset/animation_manager.go
@@ -5,15 +5,18 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-
-	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 )
 
 const (
 	animationBudget = 64
 )
+
+// Static checks to confirm struct conforms to interface
+var _ d2interface.ArchivedAnimationManager = &animationManager{}
+var _ d2interface.Cacher = &animationManager{}
 
 type animationManager struct {
 	cache    d2interface.Cache
@@ -37,7 +40,7 @@ func createAnimationManager(renderer d2interface.Renderer) *animationManager {
 
 func (am *animationManager) LoadAnimation(
 	animationPath, palettePath string,
-	effect d2enum.DrawEffect ) (d2interface.Animation, error) {
+	effect d2enum.DrawEffect) (d2interface.Animation, error) {
 	cachePath := fmt.Sprintf("%s;%s;%d", animationPath, palettePath, effect)
 	if animation, found := am.cache.Retrieve(cachePath); found {
 		return animation.(d2interface.Animation).Clone(), nil

--- a/d2core/d2asset/archive_manager.go
+++ b/d2core/d2asset/archive_manager.go
@@ -11,6 +11,10 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2config"
 )
 
+// Static checks to confirm struct conforms to interface
+var _ d2interface.ArchiveManager = &archiveManager{}
+var _ d2interface.Cacher = &archiveManager{}
+
 type archiveManager struct {
 	cache    d2interface.Cache
 	config   *d2config.Configuration

--- a/d2core/d2asset/archived_file_manager.go
+++ b/d2core/d2asset/archived_file_manager.go
@@ -13,6 +13,10 @@ const (
 	fileBudget = 1024 * 1024 * 32
 )
 
+// Static checks to confirm struct conforms to interface
+var _ d2interface.ArchivedFileManager = &fileManager{}
+var _ d2interface.Cacher = &fileManager{}
+
 type fileManager struct {
 	cache          d2interface.Cache
 	archiveManager d2interface.ArchiveManager

--- a/d2core/d2asset/dc6_animation.go
+++ b/d2core/d2asset/dc6_animation.go
@@ -2,11 +2,13 @@ package d2asset
 
 import (
 	"errors"
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2dcc"
 	d2iface "github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
+
+var _ d2iface.Animation = &DC6Animation{} // Static check to confirm struct conforms to interface
 
 // DC6Animation is an animation made from a DC6 file
 type DC6Animation struct {

--- a/d2core/d2asset/dcc_animation.go
+++ b/d2core/d2asset/dcc_animation.go
@@ -11,7 +11,9 @@ import (
 	d2iface "github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
 
-// DCCAnimation represens an animation decoded from DCC
+var _ d2iface.Animation = &DCCAnimation{} // Static check to confirm struct conforms to interface
+
+// DCCAnimation represents an animation decoded from DCC
 type DCCAnimation struct {
 	animation
 	dccPath  string

--- a/d2core/d2asset/font.go
+++ b/d2core/d2asset/font.go
@@ -6,10 +6,11 @@ import (
 	"image/color"
 	"strings"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
+
+var _ d2interface.Font = &Font{} // Static check to confirm struct conforms to interface
 
 type fontGlyph struct {
 	frame  int

--- a/d2core/d2asset/font_manager.go
+++ b/d2core/d2asset/font_manager.go
@@ -2,14 +2,18 @@ package d2asset
 
 import (
 	"fmt"
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
 
 const (
 	fontBudget = 64
 )
+
+// Static checks to confirm struct conforms to interface
+var _ d2interface.ArchivedFontManager = &fontManager{}
+var _ d2interface.Cacher = &fontManager{}
 
 type fontManager struct {
 	cache d2interface.Cache

--- a/d2core/d2asset/palette_manager.go
+++ b/d2core/d2asset/palette_manager.go
@@ -6,6 +6,10 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
 
+// Static checks to confirm struct conforms to interface
+var _ d2interface.ArchivedPaletteManager = &paletteManager{}
+var _ d2interface.Cacher = &paletteManager{}
+
 type paletteManager struct {
 	cache d2interface.Cache
 }

--- a/d2core/d2audio/ebiten/ebiten_audio_provider.go
+++ b/d2core/d2audio/ebiten/ebiten_audio_provider.go
@@ -5,14 +5,15 @@ import (
 	"log"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
-	"github.com/hajimehoshi/ebiten/audio/wav"
 
 	"github.com/hajimehoshi/ebiten/audio"
+	"github.com/hajimehoshi/ebiten/audio/wav"
 )
 
 const sampleRate = 44100
+
+var _ d2interface.AudioProvider = &AudioProvider{} // Static check to confirm struct conforms to interface
 
 // AudioProvider represents a provider capable of playing audio
 type AudioProvider struct {

--- a/d2core/d2input/input_events.go
+++ b/d2core/d2input/input_events.go
@@ -2,7 +2,15 @@ package d2input
 
 import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
+
+// Static checks to confirm struct conforms to interface
+var _ d2interface.InputEventHandler = &HandlerEvent{}
+var _ d2interface.KeyEvent = &KeyEvent{}
+var _ d2interface.KeyCharsEvent = &KeyCharsEvent{}
+var _ d2interface.MouseEvent = &MouseEvent{}
+var _ d2interface.MouseMoveEvent = &MouseMoveEvent{}
 
 // HandlerEvent is an event that EventHandlers will process and respond to
 type HandlerEvent struct {


### PR DESCRIPTION
A fairly common pattern that I've seen - this removes a class of issues with respect to runtime interface checks, but will also make it easier to confirm implementations are conforming to interfaces (i.e fail fast).

https://golang.org/doc/effective_go.html#blank_implements