### PR TITLE
rely on App to know how to navigate between screens using a callback …

### DIFF
--- a/d2core/d2screen/d2screen.go
+++ b/d2core/d2screen/d2screen.go
@@ -126,19 +126,16 @@ type loadingUpdate struct {
 }
 
 // Error provides a way for callers to report an error during loading.
-// This is meant to be delivered via the progress channel in OnLoad implementations.
 func (l *LoadingState) Error(err error) {
 	l.updates <- loadingUpdate{err: err}
 }
 
 // Progress provides a way for callers to report the ratio between `0` and `1` of the progress made loading a screen.
-// This is meant to be delivered via the progress channel in OnLoad implementations.
 func (l *LoadingState) Progress(ratio float64) {
 	l.updates <- loadingUpdate{progress: ratio}
 }
 
 // Done provides a way for callers to report that screen loading has been completed.
-// This is meant to be delivered via the progress channel in OnLoad implementations.
 func (l *LoadingState) Done() {
 	l.updates <- loadingUpdate{progress: 1.0}
 	l.updates <- loadingUpdate{done: true}

--- a/d2game/d2gamescreen/credits.go
+++ b/d2game/d2gamescreen/credits.go
@@ -15,7 +15,6 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2screen"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2ui"
-	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 )
 
 type labelItem struct {
@@ -33,24 +32,20 @@ type Credits struct {
 	cycleTime          float64
 	cyclesTillNextLine int
 	doneWithCredits    bool
-	renderer           d2interface.Renderer
-	inputManager       d2interface.InputManager
-	audioProvider      d2interface.AudioProvider
-	terminal           d2interface.Terminal
-	scriptEngine       *d2script.ScriptEngine
+
+	renderer  d2interface.Renderer
+	navigator Navigator
 }
 
 // CreateCredits creates an instance of the credits screen
-func CreateCredits(renderer d2interface.Renderer, inputManager d2interface.InputManager, audioProvider d2interface.AudioProvider, scriptEngine *d2script.ScriptEngine) *Credits {
+func CreateCredits(navigator Navigator, renderer d2interface.Renderer) *Credits {
 	result := &Credits{
 		labels:             make([]*labelItem, 0),
 		cycleTime:          0,
 		doneWithCredits:    false,
 		cyclesTillNextLine: 0,
 		renderer:           renderer,
-		inputManager:       inputManager,
-		audioProvider:      audioProvider,
-		scriptEngine:       scriptEngine,
+		navigator:          navigator,
 	}
 
 	return result
@@ -162,9 +157,7 @@ func (v *Credits) Advance(tickTime float64) error {
 }
 
 func (v *Credits) onExitButtonClicked() {
-	mainMenu := CreateMainMenu(v.renderer, v.inputManager, v.audioProvider, v.terminal, v.scriptEngine)
-	mainMenu.setScreenMode(screenModeMainMenu)
-	d2screen.SetNextScreen(mainMenu)
+	v.navigator.ToMainMenu()
 }
 
 func (v *Credits) addNextItem() {

--- a/d2game/d2gamescreen/escape_menu.go
+++ b/d2game/d2gamescreen/escape_menu.go
@@ -7,8 +7,6 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2screen"
-	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 )
 
 // TODO: fix pentagram
@@ -69,10 +67,8 @@ type EscapeMenu struct {
 	layouts   []*layout
 
 	renderer      d2interface.Renderer
-	inputManager  d2interface.InputManager
 	audioProvider d2interface.AudioProvider
-	terminal      d2interface.Terminal
-	scriptEngine  *d2script.ScriptEngine
+	navigator     Navigator
 }
 
 type layout struct {
@@ -126,14 +122,11 @@ type actionableElement interface {
 }
 
 // NewEscapeMenu creates a new escape menu
-func NewEscapeMenu(renderer d2interface.Renderer, inputManager d2interface.InputManager, audioProvider d2interface.AudioProvider, term d2interface.Terminal,
-	scriptEngine *d2script.ScriptEngine) *EscapeMenu {
+func NewEscapeMenu(navigator Navigator, renderer d2interface.Renderer, audioProvider d2interface.AudioProvider) *EscapeMenu {
 	m := &EscapeMenu{
-		inputManager:  inputManager,
 		audioProvider: audioProvider,
-		terminal:      term,
 		renderer:      renderer,
-		scriptEngine:  scriptEngine,
+		navigator:     navigator,
 	}
 
 	m.layouts = []*layout{
@@ -373,10 +366,7 @@ func (m *EscapeMenu) showLayout(id layoutID) {
 	}
 
 	if id == saveLayoutID {
-		mainMenu := CreateMainMenu(m.renderer, m.inputManager, m.audioProvider, m.terminal, m.scriptEngine)
-		mainMenu.setScreenMode(screenModeMainMenu)
-		d2screen.SetNextScreen(mainMenu)
-
+		m.navigator.ToMainMenu()
 		return
 	}
 

--- a/d2game/d2gamescreen/game.go
+++ b/d2game/d2gamescreen/game.go
@@ -14,7 +14,6 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2game/d2player"
 	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client"
 	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2netpacket"
-	"github.com/OpenDiablo2/OpenDiablo2/d2script"
 )
 
 const hideZoneTextAfterSeconds = 2.0
@@ -36,8 +35,7 @@ type Game struct {
 }
 
 // CreateGame creates the Gameplay screen and returns a pointer to it
-func CreateGame(renderer d2interface.Renderer, inputManager d2interface.InputManager, audioProvider d2interface.AudioProvider, gameClient *d2client.GameClient,
-	term d2interface.Terminal, scriptEngine *d2script.ScriptEngine) *Game {
+func CreateGame(navigator Navigator, renderer d2interface.Renderer, inputManager d2interface.InputManager, audioProvider d2interface.AudioProvider, gameClient *d2client.GameClient, term d2interface.Terminal) *Game {
 	result := &Game{
 		gameClient:           gameClient,
 		gameControls:         nil,
@@ -45,7 +43,7 @@ func CreateGame(renderer d2interface.Renderer, inputManager d2interface.InputMan
 		lastRegionType:       d2enum.RegionNone,
 		ticksSinceLevelCheck: 0,
 		mapRenderer:          d2maprenderer.CreateMapRenderer(renderer, gameClient.MapEngine, term),
-		escapeMenu:           NewEscapeMenu(renderer, inputManager, audioProvider, term, scriptEngine),
+		escapeMenu:           NewEscapeMenu(navigator, renderer, audioProvider),
 		inputManager:         inputManager,
 		audioProvider:        audioProvider,
 		renderer:             renderer,

--- a/d2game/d2gamescreen/navigate.go
+++ b/d2game/d2gamescreen/navigate.go
@@ -1,0 +1,14 @@
+package d2gamescreen
+
+import (
+	"github.com/OpenDiablo2/OpenDiablo2/d2networking/d2client/d2clientconnectiontype"
+)
+
+type Navigator interface {
+	ToMainMenu()
+	ToSelectHero(connType d2clientconnectiontype.ClientConnectionType, connHost string)
+	ToCreateGame(filePath string, connType d2clientconnectiontype.ClientConnectionType, connHost string)
+	ToCharacterSelect(connType d2clientconnectiontype.ClientConnectionType, connHost string)
+	ToMapEngineTest(region int, level int)
+	ToCredits()
+}


### PR DESCRIPTION
…interface with explicit methods

remove unused struct vars that were only stored in order to pass to the next screens

consolidate create game code to single method

export ScreenMode consts and SetScreenMode method to allow app to create the correct screens


I decided against a `sceneManager.SetNextScene(d2enum.SceneMainMenu)` method for a couple reasons. With explicit methods, we can keep the method smaller and easier to understand. Secondly, we can define what parameters are needed for the specific action.