### PR TITLE
Removing lint errors in npc.go, mapstamp.go

### DIFF
--- a/d2common/d2enum/npc_action_type.go
+++ b/d2common/d2enum/npc_action_type.go
@@ -1,0 +1,14 @@
+package d2enum
+
+// NPCActionType determines composite mode animations for NPC's as they move around
+type NPCActionType int
+
+// NPCAction types
+// TODO: Figure out what 1-3 are for
+const (
+	NPCActionInvalid NPCActionType = iota
+	NPCAction1
+	NPCAction2
+	NPCAction3
+	NPCActionSkill1
+)


### PR DESCRIPTION
- made an enum for NPCActionType to get rid of magic numbers
- moved the enum to d2enum
- fixed lint errors in npc.go
- fixed lint errors in mapstamp.go (because it was using npc.go)