### PR TITLE
removing lint errors from d2render

### DIFF
--- a/d2app/app.go
+++ b/d2app/app.go
@@ -267,24 +267,24 @@ func (p *App) renderDebug(target d2interface.Surface) error {
 	cx, cy := p.renderer.GetCursorPos()
 
 	target.PushTranslation(5, 565)
-	target.DrawText("vsync:" + strconv.FormatBool(vsyncEnabled) + "\nFPS:" + strconv.Itoa(int(fps)))
+	target.DrawTextf("vsync:" + strconv.FormatBool(vsyncEnabled) + "\nFPS:" + strconv.Itoa(int(fps)))
 	target.Pop()
 
 	var m runtime.MemStats
 
 	runtime.ReadMemStats(&m)
 	target.PushTranslation(680, 0)
-	target.DrawText("Alloc    " + strconv.FormatInt(int64(m.Alloc)/bytesToMegabyte, 10))
+	target.DrawTextf("Alloc    " + strconv.FormatInt(int64(m.Alloc)/bytesToMegabyte, 10))
 	target.PushTranslation(0, 16)
-	target.DrawText("TAlloc/s " + strconv.FormatFloat(p.allocRate(m.TotalAlloc, fps), 'f', 2, 64))
+	target.DrawTextf("TAlloc/s " + strconv.FormatFloat(p.allocRate(m.TotalAlloc, fps), 'f', 2, 64))
 	target.PushTranslation(0, 16)
-	target.DrawText("Pause    " + strconv.FormatInt(int64(m.PauseTotalNs/bytesToMegabyte), 10))
+	target.DrawTextf("Pause    " + strconv.FormatInt(int64(m.PauseTotalNs/bytesToMegabyte), 10))
 	target.PushTranslation(0, 16)
-	target.DrawText("HeapSys  " + strconv.FormatInt(int64(m.HeapSys/bytesToMegabyte), 10))
+	target.DrawTextf("HeapSys  " + strconv.FormatInt(int64(m.HeapSys/bytesToMegabyte), 10))
 	target.PushTranslation(0, 16)
-	target.DrawText("NumGC    " + strconv.FormatInt(int64(m.NumGC), 10))
+	target.DrawTextf("NumGC    " + strconv.FormatInt(int64(m.NumGC), 10))
 	target.PushTranslation(0, 16)
-	target.DrawText("Coords   " + strconv.FormatInt(int64(cx), 10) + "," + strconv.FormatInt(int64(cy), 10))
+	target.DrawTextf("Coords   " + strconv.FormatInt(int64(cx), 10) + "," + strconv.FormatInt(int64(cy), 10))
 	target.PopN(debugPopN)
 
 	return nil
@@ -598,7 +598,7 @@ func updateInitError(target d2interface.Surface) error {
 	width, height := target.GetSize()
 
 	target.PushTranslation(width/5, height/2)
-	target.DrawText(`Could not find the MPQ files in the directory: 
+	target.DrawTextf(`Could not find the MPQ files in the directory: 
 		%s\nPlease put the files and re-run the game.`, d2config.Config.MpqPath)
 
 	return nil

--- a/d2common/d2interface/surface.go
+++ b/d2common/d2interface/surface.go
@@ -12,7 +12,7 @@ type Surface interface {
 	Clear(color color.Color) error
 	DrawRect(width, height int, color color.Color)
 	DrawLine(x, y int, color color.Color)
-	DrawText(format string, params ...interface{})
+	DrawTextf(format string, params ...interface{})
 	GetSize() (width, height int)
 	GetDepth() int
 	Pop()

--- a/d2core/d2map/d2maprenderer/renderer.go
+++ b/d2core/d2map/d2maprenderer/renderer.go
@@ -325,7 +325,7 @@ func (mr *MapRenderer) renderTileDebug(ax, ay int, debugVisLevel int, target d2i
 	target.DrawLine(screenX2-screenX1, screenY2-screenY1, tileColor)
 	target.DrawLine(screenX3-screenX1, screenY3-screenY1, tileColor)
 	target.PushTranslation(-10, 10)
-	target.DrawText("%v, %v", ax, ay)
+	target.DrawTextf("%v, %v", ax, ay)
 	target.Pop()
 
 	if debugVisLevel > 1 {
@@ -346,14 +346,14 @@ func (mr *MapRenderer) renderTileDebug(ax, ay int, debugVisLevel int, target d2i
 
 		/*for i, floor := range tile.Floors {
 			target.PushTranslation(-20, 10+(i+1)*14)
-			target.DrawText("f: %v-%v", floor.Style, floor.Sequence)
+			target.DrawTextf("f: %v-%v", floor.Style, floor.Sequence)
 			target.Pop()
 		}*/
 
 		for i, wall := range tile.Walls {
 			if wall.Type.Special() {
 				target.PushTranslation(-20, 10+(i+1)*14)
-				target.DrawText("s: %v-%v", wall.Style, wall.Sequence)
+				target.DrawTextf("s: %v-%v", wall.Style, wall.Sequence)
 				target.Pop()
 			}
 		}

--- a/d2core/d2render/ebiten/doc.go
+++ b/d2core/d2render/ebiten/doc.go
@@ -1,0 +1,2 @@
+// Package ebiten provides a renderer implementation using Ebiten
+package ebiten

--- a/d2core/d2render/ebiten/ebiten_renderer.go
+++ b/d2core/d2render/ebiten/ebiten_renderer.go
@@ -10,26 +10,37 @@ import (
 	"github.com/hajimehoshi/ebiten/ebitenutil"
 )
 
+const (
+	screenWidth  = 800
+	screenHeight = 600
+)
+
+// Renderer is an implementation of a renderer
 type Renderer struct {
 	renderCallback func(surface d2interface.Surface) error
 }
 
+// Update updates the screen with the given *ebiten.Image
 func (r *Renderer) Update(screen *ebiten.Image) error {
 	err := r.renderCallback(createEbitenSurface(screen))
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
-func (r *Renderer) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
-	return 800, 600
+// Layout returns the renderer screen width and height
+func (r *Renderer) Layout(_, _ int) (width, height int) {
+	return screenWidth, screenHeight
 }
 
+// CreateRenderer creates an ebiten renderer instance
 func CreateRenderer() (*Renderer, error) {
 	result := &Renderer{}
 
 	config := d2config.Config
+
 	ebiten.SetCursorMode(ebiten.CursorModeHidden)
 	ebiten.SetFullscreen(config.FullScreen)
 	ebiten.SetRunnableOnUnfocused(config.RunInBackground)
@@ -39,10 +50,12 @@ func CreateRenderer() (*Renderer, error) {
 	return result, nil
 }
 
+// GetRendererName returns the name of the renderer
 func (*Renderer) GetRendererName() string {
 	return "Ebiten"
 }
 
+// SetWindowIcon sets the icon for the window, visible in the chrome of the window
 func (*Renderer) SetWindowIcon(fileName string) {
 	_, iconImage, err := ebitenutil.NewImageFromFile(fileName, ebiten.FilterLinear)
 	if err == nil {
@@ -50,18 +63,23 @@ func (*Renderer) SetWindowIcon(fileName string) {
 	}
 }
 
+// IsDrawingSkipped returns a bool for whether or not the drawing has been skipped
 func (r *Renderer) IsDrawingSkipped() bool {
 	return ebiten.IsDrawingSkipped()
 }
 
+// Run initializes the renderer
 func (r *Renderer) Run(f func(surface d2interface.Surface) error, width, height int, title string) error {
 	r.renderCallback = f
+
 	ebiten.SetWindowTitle(title)
 	ebiten.SetWindowResizable(true)
 	ebiten.SetWindowSize(width, height)
+
 	return ebiten.RunGame(r)
 }
 
+// CreateSurface creates a renderer surface from an existing surface
 func (r *Renderer) CreateSurface(surface d2interface.Surface) (d2interface.Surface, error) {
 	result := createEbitenSurface(
 		surface.(*ebitenSurface).image,
@@ -74,35 +92,44 @@ func (r *Renderer) CreateSurface(surface d2interface.Surface) (d2interface.Surfa
 	return result, nil
 }
 
+// NewSurface creates a new surface
 func (r *Renderer) NewSurface(width, height int, filter d2enum.Filter) (d2interface.Surface, error) {
 	ebitenFilter := d2ToEbitenFilter(filter)
 	img, err := ebiten.NewImage(width, height, ebitenFilter)
+
 	if err != nil {
 		return nil, err
 	}
+
 	return createEbitenSurface(img), nil
 }
 
+// IsFullScreen returns a boolean for whether or not the renderer is currently set to fullscreen
 func (r *Renderer) IsFullScreen() bool {
 	return ebiten.IsFullscreen()
 }
 
+// SetFullScreen sets the renderer to fullscreen, given a boolean
 func (r *Renderer) SetFullScreen(fullScreen bool) {
 	ebiten.SetFullscreen(fullScreen)
 }
 
+// SetVSyncEnabled enables vsync, given a boolean
 func (r *Renderer) SetVSyncEnabled(vsync bool) {
 	ebiten.SetVsyncEnabled(vsync)
 }
 
+// GetVSyncEnabled returns a boolean for whether or not vsync is enabled
 func (r *Renderer) GetVSyncEnabled() bool {
 	return ebiten.IsVsyncEnabled()
 }
 
-func (r *Renderer) GetCursorPos() (int, int) {
+// GetCursorPos returns the current cursor position x,y coordinates
+func (r *Renderer) GetCursorPos() (x, y int) {
 	return ebiten.CursorPosition()
 }
 
+// CurrentFPS returns the current frames per second of the renderer
 func (r *Renderer) CurrentFPS() float64 {
 	return ebiten.CurrentFPS()
 }

--- a/d2core/d2render/ebiten/filter_helper.go
+++ b/d2core/d2render/ebiten/filter_helper.go
@@ -1,8 +1,9 @@
 package ebiten
 
 import (
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 	"github.com/hajimehoshi/ebiten"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 )
 
 func d2ToEbitenFilter(filter d2enum.Filter) ebiten.Filter {
@@ -18,15 +19,15 @@ func d2ToEbitenFilter(filter d2enum.Filter) ebiten.Filter {
 	return ebiten.FilterDefault
 }
 
-func ebitenToD2Filter(filter ebiten.Filter) d2enum.Filter {
-	switch filter {
-	case ebiten.FilterDefault:
-		return d2enum.FilterDefault
-	case ebiten.FilterLinear:
-		return d2enum.FilterLinear
-	case ebiten.FilterNearest:
-		return d2enum.FilterNearest
-	}
-
-	return d2enum.FilterDefault
-}
+// func ebitenToD2Filter(filter ebiten.Filter) d2enum.Filter {
+// 	switch filter {
+// 	case ebiten.FilterDefault:
+// 		return d2enum.FilterDefault
+// 	case ebiten.FilterLinear:
+// 		return d2enum.FilterLinear
+// 	case ebiten.FilterNearest:
+// 		return d2enum.FilterNearest
+// 	}
+//
+// 	return d2enum.FilterDefault
+// }

--- a/d2core/d2render/ebiten/surface_state.go
+++ b/d2core/d2render/ebiten/surface_state.go
@@ -3,8 +3,9 @@ package ebiten
 import (
 	"image/color"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 	"github.com/hajimehoshi/ebiten"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 )
 
 type surfaceState struct {

--- a/d2core/d2term/terminal.go
+++ b/d2core/d2term/terminal.go
@@ -234,7 +234,7 @@ func (t *terminal) Render(surface d2interface.Surface) error {
 		historyEntry := t.outputHistory[historyIndex]
 
 		surface.PushTranslation(termCharWidth*2, outputHeight-(i+1)*termCharHeight)
-		surface.DrawText(historyEntry.text)
+		surface.DrawTextf(historyEntry.text)
 		surface.PushTranslation(-termCharWidth*2, 0)
 
 		switch historyEntry.category {
@@ -252,7 +252,7 @@ func (t *terminal) Render(surface d2interface.Surface) error {
 
 	surface.PushTranslation(0, outputHeight)
 	surface.DrawRect(totalWidth, termCharHeight, t.fgColor)
-	surface.DrawText("> " + t.command)
+	surface.DrawTextf("> " + t.command)
 	surface.Pop()
 
 	surface.Pop()

--- a/d2game/d2gamescreen/map_engine_testing.go
+++ b/d2game/d2gamescreen/map_engine_testing.go
@@ -197,13 +197,13 @@ func (met *MapEngineTest) Render(screen d2interface.Surface) error {
 	met.mapRenderer.Render(screen)
 
 	screen.PushTranslation(0, 16)
-	screen.DrawText("N - next region, P - previous region")
+	screen.DrawTextf("N - next region, P - previous region")
 	screen.PushTranslation(0, 16)
-	screen.DrawText("Shift+N - next preset, Shift+P - previous preset")
+	screen.DrawTextf("Shift+N - next preset, Shift+P - previous preset")
 	screen.PushTranslation(0, 16)
-	screen.DrawText("Ctrl+N - next file, Ctrl+P - previous file")
+	screen.DrawTextf("Ctrl+N - next file, Ctrl+P - previous file")
 	screen.PushTranslation(0, 16)
-	screen.DrawText("Left click selects tile, right click unselects")
+	screen.DrawTextf("Left click selects tile, right click unselects")
 	screen.PushTranslation(0, 16)
 
 	popN := 5
@@ -212,13 +212,13 @@ func (met *MapEngineTest) Render(screen d2interface.Surface) error {
 		screen.PushTranslation(15, 16)
 		popN++
 
-		screen.DrawText("No tile selected")
+		screen.DrawTextf("No tile selected")
 	} else {
 		screen.PushTranslation(10, 32)
-		screen.DrawText("Tile %v,%v", met.selX, met.selY)
+		screen.DrawTextf("Tile %v,%v", met.selX, met.selY)
 
 		screen.PushTranslation(15, 16)
-		screen.DrawText("Walls")
+		screen.DrawTextf("Walls")
 		tpop := 0
 		for _, wall := range met.selectedTile.Walls {
 			screen.PushTranslation(0, 12)
@@ -230,13 +230,13 @@ func (met *MapEngineTest) Render(screen d2interface.Surface) error {
 			for _, str := range stringSlice {
 				screen.PushTranslation(0, 12)
 				tpop++
-				screen.DrawText(str)
+				screen.DrawTextf(str)
 			}
 		}
 		screen.PopN(tpop)
 
 		screen.PushTranslation(170, 0)
-		screen.DrawText("Floors")
+		screen.DrawTextf("Floors")
 		tpop = 0
 		for _, floor := range met.selectedTile.Floors {
 			screen.PushTranslation(0, 12)
@@ -248,14 +248,14 @@ func (met *MapEngineTest) Render(screen d2interface.Surface) error {
 			for _, str := range stringSlice {
 				screen.PushTranslation(0, 12)
 				tpop++
-				screen.DrawText(str)
+				screen.DrawTextf(str)
 			}
 		}
 		screen.PopN(tpop)
 
 		tpop = 0
 		screen.PushTranslation(170, 0)
-		screen.DrawText("Shadows")
+		screen.DrawTextf("Shadows")
 		for _, shadow := range met.selectedTile.Shadows {
 			screen.PushTranslation(0, 12)
 			tpop++
@@ -266,14 +266,14 @@ func (met *MapEngineTest) Render(screen d2interface.Surface) error {
 			for _, str := range stringSlice {
 				screen.PushTranslation(0, 12)
 				tpop++
-				screen.DrawText(str)
+				screen.DrawTextf(str)
 			}
 		}
 		screen.PopN(tpop)
 
 		tpop = 0
 		screen.PushTranslation(170, 0)
-		screen.DrawText("Substitutions")
+		screen.DrawTextf("Substitutions")
 		for _, subst := range met.selectedTile.Substitutions {
 			screen.PushTranslation(0, 12)
 			tpop++
@@ -284,7 +284,7 @@ func (met *MapEngineTest) Render(screen d2interface.Surface) error {
 			for _, str := range stringSlice {
 				screen.PushTranslation(0, 12)
 				tpop++
-				screen.DrawText(str)
+				screen.DrawTextf(str)
 			}
 		}
 		screen.PopN(tpop)


### PR DESCRIPTION
I've left only the TODO's

The edits outside of d2render or to fix the lint error for `DrawText`, which should be called `DrawTextf` because it formats the string.