### PR TITLE
fix most of the remaining lint errors in d2fileformats

### DIFF
--- a/d2common/d2fileformats/d2cof/cof_dir_lookup.go
+++ b/d2common/d2fileformats/d2cof/cof_dir_lookup.go
@@ -1,5 +1,15 @@
 package d2cof
 
+type directionCount int
+
+const (
+	four directionCount = 4 << iota
+	eight
+	sixteen
+	thirtyTwo
+	sixtyFour
+)
+
 // Dir64ToCof returns the cof direction based on the actual direction
 func Dir64ToCof(direction, numDirections int) int {
 	var dir4 = [64]int{
@@ -32,16 +42,16 @@ func Dir64ToCof(direction, numDirections int) int {
 		32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
 		48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63}
 
-	switch numDirections {
-	case 4:
+	switch directionCount(numDirections) {
+	case four:
 		return dir4[direction]
-	case 8:
+	case eight:
 		return dir8[direction]
-	case 16:
+	case sixteen:
 		return dir16[direction]
-	case 32:
+	case thirtyTwo:
 		return dir32[direction]
-	case 64:
+	case sixtyFour:
 		return dir64[direction]
 	default:
 		return 0

--- a/d2common/d2fileformats/d2dat/dat_color.go
+++ b/d2common/d2fileformats/d2dat/dat_color.go
@@ -10,11 +10,11 @@ type DATColor struct {
 
 const (
 	colorBits = 8
-	mask = 0xff
+	mask      = 0xff
 )
 
 const (
-	bitShift0 = iota*colorBits
+	bitShift0 = iota * colorBits
 	bitShift8
 	bitShift16
 	bitShift24
@@ -50,28 +50,30 @@ func (c *DATColor) SetRGBA(rgba uint32) {
 	c.r, c.g, c.b, c.a = toComponent(rgba)
 }
 
+// BGRA gets the combination of the color components (0xBBGGRRAA)
 func (c *DATColor) BGRA() uint32 {
 	return toComposite(c.b, c.g, c.r, c.a)
 }
 
+// SetBGRA sets the color components using the given BGRA form
 func (c *DATColor) SetBGRA(bgra uint32) {
 	c.b, c.g, c.r, c.a = toComponent(bgra)
 }
 
-func toComposite (w,x,y,z uint8) uint32 {
-	composite := uint32(w)<<bitShift24
-	composite += uint32(x)<<bitShift16
-	composite += uint32(y)<<bitShift8
-	composite += uint32(z)<<bitShift0
+func toComposite(w, x, y, z uint8) uint32 {
+	composite := uint32(w) << bitShift24
+	composite += uint32(x) << bitShift16
+	composite += uint32(y) << bitShift8
+	composite += uint32(z) << bitShift0
 
 	return composite
 }
 
-func toComponent (wxyz uint32) (w,x,y,z uint8){
-	w = uint8(wxyz>>bitShift24 & mask)
-	x = uint8(wxyz>>bitShift16 & mask)
-	y = uint8(wxyz>>bitShift8 & mask)
-	z = uint8(wxyz>>bitShift0 & mask)
+func toComponent(wxyz uint32) (w, x, y, z uint8) {
+	w = uint8(wxyz >> bitShift24 & mask)
+	x = uint8(wxyz >> bitShift16 & mask)
+	y = uint8(wxyz >> bitShift8 & mask)
+	z = uint8(wxyz >> bitShift0 & mask)
+
 	return w, x, y, z
 }
-

--- a/d2common/d2fileformats/d2dat/dat_palette.go
+++ b/d2common/d2fileformats/d2dat/dat_palette.go
@@ -2,6 +2,7 @@ package d2dat
 
 import (
 	"fmt"
+
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
 

--- a/d2common/d2fileformats/d2dc6/dc6.go
+++ b/d2common/d2fileformats/d2dc6/dc6.go
@@ -4,6 +4,11 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 )
 
+const (
+	endOfScanLine = 0x80
+	maxRunLength  = 0x7f
+)
+
 // DC6 represents a DC6 file.
 type DC6 struct {
 	Version            int32
@@ -41,6 +46,7 @@ func Load(data []byte) (*DC6, error) {
 	}
 
 	dc.Frames = make([]*DC6Frame, frameCount)
+
 	for i := 0; i < frameCount; i++ {
 		frame := &DC6Frame{
 			Flipped:   r.GetUInt32(),
@@ -73,7 +79,7 @@ func (d *DC6) DecodeFrame(frameIndex int) []byte {
 		b := int(frame.FrameData[offset])
 		offset++
 
-		if b == 0x80 {
+		if b == endOfScanLine {
 			if y == 0 {
 				break
 			}
@@ -81,8 +87,8 @@ func (d *DC6) DecodeFrame(frameIndex int) []byte {
 			y--
 
 			x = 0
-		} else if b&0x80 > 0 {
-			transparentPixels := b & 0x7f
+		} else if b&endOfScanLine > 0 {
+			transparentPixels := b & maxRunLength
 			x += transparentPixels
 		} else {
 			for i := 0; i < b; i++ {

--- a/d2common/d2fileformats/d2dcc/dcc_dir_lookup.go
+++ b/d2common/d2fileformats/d2dcc/dcc_dir_lookup.go
@@ -1,5 +1,15 @@
 package d2dcc
 
+type directionCount int
+
+const (
+	four directionCount = 4 << iota
+	eight
+	sixteen
+	thirtyTwo
+	sixtyFour
+)
+
 // Dir64ToDcc returns the DCC direction based on the actual direction.
 // Special thanks for Necrolis for these tables!
 func Dir64ToDcc(direction, numDirections int) int {
@@ -33,16 +43,16 @@ func Dir64ToDcc(direction, numDirections int) int {
 		6, 48, 24, 49, 12, 50, 25, 51, 2, 52, 26, 53, 13, 54, 27, 55,
 		7, 56, 28, 57, 14, 58, 29, 59, 3, 60, 30, 61, 15, 62, 31, 63}
 
-	switch numDirections {
-	case 4:
+	switch directionCount(numDirections) {
+	case four:
 		return dir4[direction]
-	case 8:
+	case eight:
 		return dir8[direction]
-	case 16:
+	case sixteen:
 		return dir16[direction]
-	case 32:
+	case thirtyTwo:
 		return dir32[direction]
-	case 64:
+	case sixtyFour:
 		return dir64[direction]
 	default:
 		return 0

--- a/d2common/d2fileformats/d2dt1/tile.go
+++ b/d2common/d2fileformats/d2dt1/tile.go
@@ -1,5 +1,6 @@
 package d2dt1
 
+// Tile is a representation of a map tile
 type Tile struct {
 	Direction          int32
 	RoofHeight         int16
@@ -16,15 +17,15 @@ type Tile struct {
 	Blocks             []Block
 }
 
-var subtileLookup = [5][5]int{
-	{20, 21, 22, 23, 24},
-	{15, 16, 17, 18, 19},
-	{10, 11, 12, 13, 14},
-	{5, 6, 7, 8, 9},
-	{0, 1, 2, 3, 4},
-}
-
+// GetSubTileFlags returns the tile flags for the given subtile
 func (t *Tile) GetSubTileFlags(x, y int) *SubTileFlags {
+	var subtileLookup = [5][5]int{
+		{20, 21, 22, 23, 24},
+		{15, 16, 17, 18, 19},
+		{10, 11, 12, 13, 14},
+		{5, 6, 7, 8, 9},
+		{0, 1, 2, 3, 4},
+	}
 
 	return &t.SubTileFlags[subtileLookup[y][x]]
 }

--- a/d2common/d2fileformats/d2mpq/hash_entry_map.go
+++ b/d2common/d2fileformats/d2mpq/hash_entry_map.go
@@ -1,6 +1,6 @@
 package d2mpq
 
-// hashEntryMap represents a hash entry map
+// HashEntryMap represents a hash entry map
 type HashEntryMap struct {
 	entries map[uint64]HashTableEntry
 }


### PR DESCRIPTION
there are 3 remaining lint errors, each for an unused `FileFlag` constant inside of `mpq.go`. not sure what to do about those.