### PR TITLE
Theta* pathfinding

### DIFF
--- a/d2common/d2astar/astar.go
+++ b/d2common/d2astar/astar.go
@@ -80,6 +80,133 @@ func (nm nodeMap) get(p Pather) *node {
 	return n
 }
 
+func isInLOS(from, to Pather) bool {
+	return true
+}
+
+func PathTheta(from, to Pather, maxCost float64) (path []Pather, distance float64, found bool) {
+	nm := nodeMapPool.Get().(nodeMap)
+	nq := priorityQueuePool.Get().(priorityQueue)
+
+	defer func() {
+		for k, v := range nm {
+			v.reset()
+			nodePool.Put(v)
+			delete(nm, k)
+		}
+
+		nq = nq[0:0]
+
+		nodeMapPool.Put(nm)
+
+		priorityQueuePool.Put(nq)
+	}()
+
+	heap.Init(&nq)
+
+	fromNode := nm.get(from)
+	fromNode.open = true
+	heap.Push(&nq, fromNode)
+
+	for {
+		if nq.Len() == 0 {
+			// There's no path, fallback to closest.
+			break
+		}
+
+		current := heap.Pop(&nq).(*node)
+
+		current.open = false
+		current.closed = true
+
+		if current == nm.get(to) {
+			// Found a path to the goal.
+			p := make([]Pather, 0, 16)
+			curr := current
+
+			for curr != nil {
+				p = append(p, curr.pather)
+				curr = curr.parent
+			}
+
+			return p, current.cost, true
+		}
+
+		for _, neighbor := range current.pather.PathNeighbors() {
+			cost := current.cost + current.pather.PathNeighborCost(neighbor)
+			if cost > maxCost {
+				// Out of range, tweak maxCost if this is cutting off too soon.
+				continue
+			}
+
+			neighborNode := nm.get(neighbor)
+			parentNode := current.parent
+
+			if parentNode != nil && isInLOS(parentNode.pather, neighborNode.pather) {
+				if cost < neighborNode.cost {
+					if neighborNode.open {
+						heap.Remove(&nq, neighborNode.index)
+					}
+
+					neighborNode.open = false
+					neighborNode.closed = false
+				}
+
+				if !neighborNode.open && !neighborNode.closed {
+					neighborNode.cost = cost
+					neighborNode.open = true
+					neighborNode.rank = cost + neighbor.PathEstimatedCost(to)
+					neighborNode.parent = parentNode
+					heap.Push(&nq, neighborNode)
+				}
+			} else {
+				if cost < neighborNode.cost {
+					if neighborNode.open {
+						heap.Remove(&nq, neighborNode.index)
+					}
+
+					neighborNode.open = false
+					neighborNode.closed = false
+				}
+
+				if !neighborNode.open && !neighborNode.closed {
+					neighborNode.cost = cost
+					neighborNode.open = true
+					neighborNode.rank = cost + neighbor.PathEstimatedCost(to)
+					neighborNode.parent = current
+					heap.Push(&nq, neighborNode)
+				}
+			}
+		}
+	}
+
+	// No path found, use closest node available, with found false to indicate the path doesn't reach the target.
+	closestNode := nm.get(from)
+	closestNode.rank = closestNode.pather.PathEstimatedCost(to)
+
+	for _, current := range nm {
+		if current.parent == nil {
+			// This node wasn't evaluated while path finding, probably isn't a good option.
+			continue
+		}
+
+		current.rank = current.pather.PathEstimatedCost(to)
+		if current.rank < closestNode.rank {
+			closestNode = current
+		}
+	}
+
+	p := make([]Pather, 0, 16)
+	curr := closestNode
+
+	for curr != nil {
+		p = append(p, curr.pather)
+		curr = curr.parent
+	}
+
+	return p, closestNode.cost, false
+}
+
 // Path calculates a short path and the distance between the two Pather nodes.
 // If no path is found, found will be false and path will be the closest node to the target with a valid path.
 func Path(from, to Pather, maxCost float64) (path []Pather, distance float64, found bool) {

--- a/d2common/d2astar/goreland_example.go
+++ b/d2common/d2astar/goreland_example.go
@@ -60,6 +60,10 @@ func (t *Truck) PathNeighbors() []Pather {
 	return neighbors
 }
 
+func (t *Truck) PathLocation() (int, int) {
+	return t.X, t.Y
+}
+
 // PathNeighborCost returns the cost of the tube leading to Truck.
 func (t *Truck) PathNeighborCost(to Pather) float64 {
 	for _, tubeElement := range (t).outTo {

--- a/d2common/d2astar/pather_test.go
+++ b/d2common/d2astar/pather_test.go
@@ -94,6 +94,11 @@ func (t *Tile) PathNeighborCost(to Pather) float64 {
 	return KindCosts[toT.Kind]
 }
 
+// PathLocation is the location of the tile
+func (t *Tile) PathLocation() (int, int) {
+	return t.X, t.Y
+}
+
 // PathEstimatedCost uses Manhattan distance to estimate orthogonal distance
 // between non-adjacent nodes.
 func (t *Tile) PathEstimatedCost(to Pather) float64 {

--- a/d2common/path_tile.go
+++ b/d2common/path_tile.go
@@ -13,6 +13,7 @@ type PathTile struct {
 	UpLeft, UpRight     *PathTile
 	DownLeft, DownRight *PathTile
 	Position            d2vector.Position
+	SubX, SubY          int
 }
 
 // PathNeighbors returns the direct neighboring nodes of this node which can be pathed to
@@ -51,6 +52,10 @@ func (t *PathTile) PathNeighbors() []d2astar.Pather {
 	}
 
 	return result
+}
+
+func (t *PathTile) PathLocation() (int, int) {
+	return t.SubX, t.SubY
 }
 
 // PathNeighborCost calculates the exact movement cost to neighbor nodes

--- a/d2core/d2map/d2mapengine/walk_mesh.go
+++ b/d2core/d2map/d2mapengine/walk_mesh.go
@@ -118,7 +118,7 @@ func (m *MapEngine) PathFind(startX, startY, endX, endY float64) (path []d2astar
 
 	endNode := &m.walkMesh[endNodeIndex]
 
-	path, distance, found = d2astar.Path(startNode, endNode, 80)
+	path, distance, found = d2astar.PathTheta(startNode, endNode, 80)
 	if path != nil {
 		// Reverse the path to fit what the game expects.
 		for i := len(path)/2 - 1; i >= 0; i-- {

--- a/d2core/d2map/d2mapengine/walk_mesh.go
+++ b/d2core/d2map/d2mapengine/walk_mesh.go
@@ -56,6 +56,8 @@ func (m *MapEngine) RegenerateWalkPaths() {
 				Position: d2vector.NewPosition(
 					float64(subTileX),
 					float64(subTileY)),
+				SubX: subTileX,
+				SubY: subTileY,
 			}
 
 			ySkew := m.size.Width * 5
@@ -118,7 +120,7 @@ func (m *MapEngine) PathFind(startX, startY, endX, endY float64) (path []d2astar
 
 	endNode := &m.walkMesh[endNodeIndex]
 
-	path, distance, found = d2astar.PathTheta(startNode, endNode, 80)
+	path, distance, found = d2astar.PathTheta(startNode, endNode, m, 80)
 	if path != nil {
 		// Reverse the path to fit what the game expects.
 		for i := len(path)/2 - 1; i >= 0; i-- {
@@ -130,4 +132,34 @@ func (m *MapEngine) PathFind(startX, startY, endX, endY float64) (path []d2astar
 	}
 
 	return
+}
+
+// QueryLOS finds out if there is a clear line of sight between two points
+func (m *MapEngine) QueryLOS(sX, sY, tX, tY int) bool {
+	dx := tX - sX
+	dy := tY - sY
+	N := math.Max(float64(dx), float64(dy))
+
+	var divN float64
+	if N == 0 {
+		divN = 0.0
+	} else {
+		divN = 1.0 / N
+	}
+
+	xstep := float64(dx) * divN
+	ystep := float64(dy) * divN
+	x := float64(sX)
+	y := float64(sY)
+
+	for i := 0; i <= int(N); i++ {
+		x += xstep
+		y += ystep
+
+		if !m.walkMesh[int(x)+(int(y)*m.size.Width*5)].Walkable {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
This implements theta* pathfinding. This is basically a* but when searching for paths we straighten them out by testing if the parent node has vision to the new neighbor node and skipping the current node if they do.

It is currently slightly buggy for reasons unkown to me and will sometimes happily run through unwalkable tiles.