### PR TITLE
entity debug rendering

### DIFF
--- a/d2common/d2interface/map_entity.go
+++ b/d2common/d2interface/map_entity.go
@@ -1,10 +1,13 @@
 package d2interface
 
+import "github.com/OpenDiablo2/OpenDiablo2/d2common/d2math/d2vector"
+
 // MapEntity is something that can be positioned on and rendered on the game map
 type MapEntity interface {
 	Render(target Surface)
 	Advance(tickTime float64)
-	GetPosition() (float64, float64)
+	GetPosition() d2vector.Position
+	GetVelocity() d2vector.Vector
 	GetLayer() int
 	GetPositionF() (float64, float64)
 	Name() string

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -73,19 +73,18 @@ func (m *mapEntity) Step(tickTime float64) {
 		return
 	}
 
-	// Set velocity (speed and direction)
 	m.setVelocity(tickTime * m.Speed)
 
-	// This loop handles the situation where the velocity exceeds the distance to the current target. Each repitition applies
-	// the remaining velocity in the direction of the next path target.
+	v := m.velocity.Clone() // Create a new vector
+
 	for {
-		applyVelocity(&m.Position.Vector, &m.velocity, &m.Target.Vector)
+		applyVelocity(&m.Position.Vector, &v, &m.Target.Vector) // Pass the new vector to the function which alters it
 
 		if m.atTarget() {
 			m.nextPath()
 		}
 
-		if m.velocity.IsZero() {
+		if v.IsZero() { // Check if the new vector is zero (keeping this as m.velocity.IsZero() would break the test (infinite loop)
 			break
 		}
 	}

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -28,6 +28,7 @@ func newMapEntity(x, y int) mapEntity {
 	return mapEntity{
 		Position: pos,
 		Target:   pos,
+		velocity: d2vector.NewVector(0, 0),
 	}
 }
 
@@ -67,25 +68,32 @@ func (m *mapEntity) Step(tickTime float64) {
 			m.done = nil
 		}
 
+		m.velocity.SetLength(0)
+
 		return
 	}
 
 	// Set velocity (speed and direction)
 	m.setVelocity(tickTime * m.Speed)
+	currVelocity := m.velocity.Clone()
+	currVelocity.SetLength(m.Speed)
 
 	// This loop handles the situation where the velocity exceeds the distance to the current target. Each repitition applies
 	// the remaining velocity in the direction of the next path target.
 	for {
-		applyVelocity(&m.Position.Vector, &m.velocity, &m.Target.Vector)
+		tmpVelocity := m.velocity.Clone()
+		applyVelocity(&m.Position.Vector, &tmpVelocity, &m.Target.Vector)
 
 		if m.atTarget() {
 			m.nextPath()
 		}
 
-		if m.velocity.IsZero() {
+		if tmpVelocity.IsZero() {
 			break
 		}
 	}
+
+	m.velocity = currVelocity
 }
 
 // atTarget returns true if the distance between entity and target is almost zero.

--- a/d2core/d2map/d2mapentity/map_entity.go
+++ b/d2core/d2map/d2mapentity/map_entity.go
@@ -75,25 +75,20 @@ func (m *mapEntity) Step(tickTime float64) {
 
 	// Set velocity (speed and direction)
 	m.setVelocity(tickTime * m.Speed)
-	currVelocity := m.velocity.Clone()
-	currVelocity.SetLength(m.Speed)
 
 	// This loop handles the situation where the velocity exceeds the distance to the current target. Each repitition applies
 	// the remaining velocity in the direction of the next path target.
 	for {
-		tmpVelocity := m.velocity.Clone()
-		applyVelocity(&m.Position.Vector, &tmpVelocity, &m.Target.Vector)
+		applyVelocity(&m.Position.Vector, &m.velocity, &m.Target.Vector)
 
 		if m.atTarget() {
 			m.nextPath()
 		}
 
-		if tmpVelocity.IsZero() {
+		if m.velocity.IsZero() {
 			break
 		}
 	}
-
-	m.velocity = currVelocity
 }
 
 // atTarget returns true if the distance between entity and target is almost zero.

--- a/d2core/d2map/d2mapentity/missile.go
+++ b/d2core/d2map/d2mapentity/missile.go
@@ -19,6 +19,14 @@ type Missile struct {
 	record *d2datadict.MissileRecord
 }
 
+func (m *Missile) GetPosition() d2vector.Position {
+	return m.AnimatedEntity.Position
+}
+
+func (m *Missile) GetVelocity() d2vector.Vector {
+	return m.AnimatedEntity.velocity
+}
+
 // CreateMissile creates a new Missile and initializes it's animation.
 func CreateMissile(x, y int, record *d2datadict.MissileRecord) (*Missile, error) {
 	animation, err := d2asset.LoadAnimation(

--- a/d2core/d2map/d2mapentity/npc.go
+++ b/d2core/d2map/d2mapentity/npc.go
@@ -1,6 +1,7 @@
 package d2mapentity
 
 import (
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2math/d2vector"
 	"math/rand"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
@@ -205,4 +206,14 @@ func (v *NPC) Selectable() bool {
 // Name returns the NPC's in-game name (e.g. "Deckard Cain") or an empty string if it does not have a name.
 func (v *NPC) Name() string {
 	return v.name
+}
+
+// GetPosition returns the NPC's position
+func (v *NPC) GetPosition() d2vector.Position {
+	return v.mapEntity.Position
+}
+
+// GetVelocity returns the NPC's velocity vector
+func (v *NPC) GetVelocity() d2vector.Vector {
+	return v.mapEntity.velocity
 }

--- a/d2core/d2map/d2mapentity/player.go
+++ b/d2core/d2map/d2mapentity/player.go
@@ -1,10 +1,10 @@
 package d2mapentity
 
 import (
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2data/d2datadict"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2math/d2vector"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2hero"
@@ -222,4 +222,14 @@ func (v *Player) SetCasting() {
 func (v *Player) Selectable() bool {
 	// Players are selectable when in town
 	return v.IsInTown()
+}
+
+// GetPosition returns the entity's position
+func (p *Player) GetPosition() d2vector.Position {
+	return p.mapEntity.Position
+}
+
+// GetVelocity returns the entity's velocity vector
+func (p *Player) GetVelocity() d2vector.Vector {
+	return p.mapEntity.velocity
 }

--- a/d2core/d2map/d2maprenderer/renderer.go
+++ b/d2core/d2map/d2maprenderer/renderer.go
@@ -331,7 +331,9 @@ func (mr *MapRenderer) renderEntityDebug(target d2interface.Surface) {
 		world := pos
 		x, y := world.X()/5, world.Y()/5
 		velocity := e.GetVelocity()
-		vx, vy := velocity.X(), velocity.Y()
+		velocity = velocity.Clone()
+		// velocity.Scale(60) // arbitrary scale value, just to make it easy to see
+		vx, vy := mr.viewport.WorldToOrtho(velocity.X(), velocity.Y())
 		screenX, screenY := mr.viewport.WorldToScreen(x, y)
 
 		offX, offY := 40, -40
@@ -345,6 +347,7 @@ func (mr *MapRenderer) renderEntityDebug(target d2interface.Surface) {
 		target.Pop()
 		target.DrawTextf("World (%.2f, %.2f)\nVelocity (%.2f, %.2f)", x, y, vx, vy)
 		target.Pop()
+		target.DrawLine(int(vx), int(vy), color.RGBA{64, 255, 0, 255})
 		target.Pop()
 		mr.viewport.PopTranslation()
 	}

--- a/d2core/d2object/object.go
+++ b/d2core/d2object/object.go
@@ -122,12 +122,6 @@ func (ob *Object) GetLayer() int {
 	return ob.drawLayer
 }
 
-// GetPosition of the object
-func (ob *Object) GetPosition() (x, y float64) {
-	w := ob.Position.Tile()
-	return w.X(), w.Y()
-}
-
 // GetPositionF of the object but differently
 func (ob *Object) GetPositionF() (x, y float64) {
 	w := ob.Position.World()
@@ -137,4 +131,14 @@ func (ob *Object) GetPositionF() (x, y float64) {
 // Name gets the name of the object
 func (ob *Object) Name() string {
 	return ob.name
+}
+
+// GetPosition returns the object's position
+func (ob *Object) GetPosition() d2vector.Position {
+	return ob.Position
+}
+
+// GetVelocity returns the object's velocity vector
+func (ob *Object) GetVelocity() d2vector.Vector {
+	return d2vector.NewVector(0, 0)
 }


### PR DESCRIPTION
needed to add getter method for position/velocity to MapEntity interface, so that's the reasoning for changing objects/npcs/player/etc

this currently brings allocs/s up to 10 (you can check by running `fps` command, se we need to look into d2debugutils and how it handles drawing text. either that, or at line `d2maprenderer/renderer.go:336` we need to return if the entity is not on-screen. I tried to do it, but gave up after about an hour.