### PR TITLE
Stats refactor

### DIFF
--- a/d2core/d2stats/diablo2stats/diablo2stats.go
+++ b/d2core/d2stats/diablo2stats/diablo2stats.go
@@ -6,15 +6,18 @@ import (
 )
 
 // NewStat creates a stat instance with the given record and values
-func NewStat(record *d2datadict.ItemStatCostRecord, values ...d2stats.StatValue) d2stats.Stat {
+func NewStat(key string, values ...float64) d2stats.Stat {
+	record := d2datadict.ItemStatCosts[key]
+
 	if record == nil {
 		return nil
 	}
 
-	stat := &Diablo2Stat{
+	stat := &diablo2Stat{
 		record: record,
-		values: values,
 	}
+
+	stat.init(values...) // init stat values, value types, and value combination rules
 
 	return stat
 }
@@ -24,22 +27,21 @@ func NewStatList(stats ...d2stats.Stat) d2stats.StatList {
 	return &Diablo2StatList{stats}
 }
 
-// NewStatValue creates a stat value of the given type
-func NewStatValue(t d2stats.StatValueType) d2stats.StatValue {
-	sv := &Diablo2StatValue{_type: t}
+// NewValue creates a stat value of the given type
+func NewValue(t d2stats.StatNumberType, c d2stats.ValueCombineType) d2stats.StatValue {
+	sv := &Diablo2StatValue{
+		numberType:  t,
+		combineType: c,
+	}
 
 	switch t {
 	case d2stats.StatValueFloat:
-		sv._stringer = stringerUnsignedFloat
+		sv.stringerFn = stringerUnsignedFloat
 	case d2stats.StatValueInt:
-		sv._stringer = stringerUnsignedInt
+		sv.stringerFn = stringerUnsignedInt
 	default:
-		sv._stringer = stringerEmpty
+		sv.stringerFn = stringerEmpty
 	}
 
 	return sv
-}
-
-func intVal(i int) d2stats.StatValue {
-	return NewStatValue(d2stats.StatValueInt).SetInt(i)
 }

--- a/d2core/d2stats/diablo2stats/stat_test.go
+++ b/d2core/d2stats/diablo2stats/stat_test.go
@@ -2,7 +2,6 @@ package diablo2stats
 
 import (
 	"fmt"
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2stats"
 	"testing"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2data/d2datadict"
@@ -261,8 +260,7 @@ func TestStat_InitMockData(t *testing.T) {
 }
 
 func TestStat_Clone(t *testing.T) {
-	r := d2datadict.ItemStatCosts["strength"]
-	s1 := NewStat(r, intVal(5))
+	s1 := NewStat("strength", 5)
 	s2 := s1.Clone()
 
 	// make sure the stats are distinct
@@ -288,89 +286,94 @@ func TestStat_Clone(t *testing.T) {
 func TestStat_Descriptions(t *testing.T) {
 	tests := []struct {
 		recordKey string
-		vals      []d2stats.StatValue
+		vals      []float64
 		expect    string
 	}{
 		// DescFn1
-		{"strength", []d2stats.StatValue{intVal(31)}, "+31 to Strength"},
-		{"hpregen", []d2stats.StatValue{intVal(20)}, "Replenish Life +20"},
-		{"hpregen", []d2stats.StatValue{intVal(-8)}, "Drain Life -8"},
+		{"strength", []float64{31}, "+31 to Strength"},
+		{"hpregen", []float64{20}, "Replenish Life +20"},
+		{"hpregen", []float64{-8}, "Drain Life -8"},
 
 		// DescFn2
-		{"toblock", []d2stats.StatValue{intVal(16)}, "+16% Increased Chance of Blocking"},
-		{"item_absorblight_percent", []d2stats.StatValue{intVal(10)}, "Lightning Absorb +10%"},
+		{"toblock", []float64{16}, "+16% Increased Chance of Blocking"},
+		{"item_absorblight_percent", []float64{10}, "Lightning Absorb +10%"},
 
 		// DescFn3
-		{"normal_damage_reduction", []d2stats.StatValue{intVal(25)}, "Damage Reduced by 25"},
-		{"item_restinpeace", []d2stats.StatValue{intVal(25)}, "Slain Monsters Rest in Peace"},
+		{"normal_damage_reduction", []float64{25}, "Damage Reduced by 25"},
+		{"item_restinpeace", []float64{25}, "Slain Monsters Rest in Peace"},
 
 		// DescFn4
-		{"poisonresist", []d2stats.StatValue{intVal(25)}, "Poison Resist +25%"},
-		{"item_fastermovevelocity", []d2stats.StatValue{intVal(25)}, "+25% Faster Run/Walk"},
+		{"poisonresist", []float64{25}, "Poison Resist +25%"},
+		{"item_fastermovevelocity", []float64{25}, "+25% Faster Run/Walk"},
 
 		// DescFn5
-		{"item_howl", []d2stats.StatValue{intVal(25)}, "Hit Causes Monster to Flee 25%"},
+		{"item_howl", []float64{25}, "Hit Causes Monster to Flee 25%"},
 
 		// DescFn6
-		{"item_hp_perlevel", []d2stats.StatValue{intVal(25)}, "+25 to Life (Based on Character Level)"},
+		{"item_hp_perlevel", []float64{25}, "+25 to Life (Based on Character Level)"},
 
 		// DescFn7
-		{"item_resist_ltng_perlevel", []d2stats.StatValue{intVal(25)}, "Lightning Resist +25% (Based on Character Level)"},
-		{"item_find_magic_perlevel", []d2stats.StatValue{intVal(25)}, "+25% Better Chance of Getting Magic Items (" +
+		{"item_resist_ltng_perlevel", []float64{25},
+			"Lightning Resist +25% (Based on Character Level)"},
+		{"item_find_magic_perlevel", []float64{25}, "+25% Better Chance of Getting Magic Items (" +
 			"Based on Character Level)"},
 
 		// DescFn8
-		{"item_armorpercent_perlevel", []d2stats.StatValue{intVal(25)}, "+25% Enhanced Defense (Based on Character Level)"},
-		{"item_regenstamina_perlevel", []d2stats.StatValue{intVal(25)},
+		{"item_armorpercent_perlevel", []float64{25},
+			"+25% Enhanced Defense (Based on Character Level)"},
+		{"item_regenstamina_perlevel", []float64{25},
 			"Heal Stamina Plus +25% (Based on Character Level)"},
 
 		// DescFn9
-		{"item_thorns_perlevel", []d2stats.StatValue{intVal(25)}, "Attacker Takes Damage of 25 (Based on Character Level)"},
+		{"item_thorns_perlevel", []float64{25}, "Attacker Takes Damage of 25 (" +
+			"Based on Character Level)"},
 
 		// DescFn11
-		{"item_replenish_durability", []d2stats.StatValue{intVal(2)}, "Repairs 2 durability per second"},
+		{"item_replenish_durability", []float64{2}, "Repairs 2 durability per second"},
 
 		// DescFn12
-		{"item_stupidity", []d2stats.StatValue{intVal(5)}, "Hit Blinds Target +5"},
+		{"item_stupidity", []float64{5}, "Hit Blinds Target +5"},
 
 		// DescFn13
-		{"item_addclassskills", []d2stats.StatValue{intVal(5), intVal(3)}, "+5 to Paladin Skill Levels"},
+		{"item_addclassskills", []float64{5, 3}, "+5 to Paladin Skill Levels"},
 
 		// DescFn14
-		{"item_addskill_tab", []d2stats.StatValue{intVal(5), intVal(3), intVal(0)}, "+5 to Combat Skills (Paladin Only)"},
-		{"item_addskill_tab", []d2stats.StatValue{intVal(5), intVal(3), intVal(1)}, "+5 to Offensive Auras (Paladin Only)"},
-		{"item_addskill_tab", []d2stats.StatValue{intVal(5), intVal(3), intVal(2)}, "+5 to Defensive Auras (Paladin Only)"},
+		{"item_addskill_tab", []float64{5, 3, 0}, "+5 to Combat Skills (Paladin Only)"},
+		{"item_addskill_tab", []float64{5, 3, 1}, "+5 to Offensive Auras (Paladin Only)"},
+		{"item_addskill_tab", []float64{5, 3, 2}, "+5 to Defensive Auras (Paladin Only)"},
 
 		// DescFn15
-		{"item_skillonattack", []d2stats.StatValue{intVal(5), intVal(7), intVal(64)}, "5% Chance to cast level 7 Frozen Orb on attack"},
+		{"item_skillonattack", []float64{5, 7, 64},
+			"5% Chance to cast level 7 Frozen Orb on attack"},
 
 		// DescFn16
-		{"item_aura", []d2stats.StatValue{intVal(3), intVal(37)}, "Level 3 Warmth Aura When Equipped"},
+		{"item_aura", []float64{3, 37}, "Level 3 Warmth Aura When Equipped"},
 
 		// DescFn20
-		{"item_fractionaltargetac", []d2stats.StatValue{intVal(-25)}, "-25% Target Defense"},
+		{"item_fractionaltargetac", []float64{-25}, "-25% Target Defense"},
 
 		// DescFn22
-		{"attack_vs_montype", []d2stats.StatValue{intVal(25), intVal(40)}, "25% to Attack Rating versus Specter"},
+		{"attack_vs_montype", []float64{25, 40}, "25% to Attack Rating versus Specter"},
 
 		// DescFn23
-		{"item_reanimate", []d2stats.StatValue{intVal(25), intVal(40)}, "25% Reanimate as: Specter"},
+		{"item_reanimate", []float64{25, 40}, "25% Reanimate as: Specter"},
 
 		// DescFn24
-		{"item_charged_skill", []d2stats.StatValue{intVal(25), intVal(64), intVal(20), intVal(19)}, "Level 25 Frozen Orb (19/20 Charges)"},
+		{"item_charged_skill", []float64{25, 64, 20, 19}, "Level 25 Frozen Orb (19/20 Charges)"},
 
 		// DescFn27
-		{"item_singleskill", []d2stats.StatValue{intVal(25), intVal(64), intVal(3)}, "+25 to Frozen Orb (Paladin Only)"},
+		{"item_singleskill", []float64{25, 64, 3}, "+25 to Frozen Orb (Paladin Only)"},
 
 		// DescFn28
-		{"item_nonclassskill", []d2stats.StatValue{intVal(25), intVal(64)}, "+25 to Frozen Orb"},
+		{"item_nonclassskill", []float64{25, 64}, "+25 to Frozen Orb"},
 	}
 
 	for idx := range tests {
 		test := tests[idx]
-		record := d2datadict.ItemStatCosts[test.recordKey]
+		key := test.recordKey
+		record := d2datadict.ItemStatCosts[key]
 		expect := test.expect
-		stat := NewStat(record, test.vals...)
+		stat := NewStat(key, test.vals...)
 
 		if got := stat.String(); got != expect {
 			t.Errorf(errFmt, errStr, record.DescFnID, test.recordKey, test.vals, expect, got)
@@ -379,5 +382,23 @@ func TestStat_Descriptions(t *testing.T) {
 			success = fmt.Sprintf(success, record.DescFnID, record.Name, test.vals, got)
 			fmt.Println(success)
 		}
+	}
+}
+
+func TestDiablo2Stat_Combine(t *testing.T) {
+	a := NewStat("item_nonclassskill", 25, 64) // "+25 to Frozen Orb"
+	b := NewStat("item_nonclassskill", 5, 64)  // "+5 to Frozen Orb"
+
+	c, err := a.Combine(b)
+
+	if err != nil || c.String() != "+30 to Frozen Orb" {
+		t.Errorf("stats combination failed\r%s", err)
+	}
+
+	d := NewStat("item_nonclassskill", 5, 37) // "+5 to Warmth"
+	_, err = c.Combine(d)
+
+	if err == nil {
+		t.Error("stats were combined when they should not have been.")
 	}
 }

--- a/d2core/d2stats/diablo2stats/stat_value.go
+++ b/d2core/d2stats/diablo2stats/stat_value.go
@@ -9,28 +9,34 @@ var _ d2stats.StatValue = &Diablo2StatValue{}
 
 // Diablo2StatValue is a diablo 2 implementation of a stat value
 type Diablo2StatValue struct {
-	number    float64
-	_stringer func(d2stats.StatValue) string
-	_type     d2stats.StatValueType
+	number      float64
+	stringerFn  func(d2stats.StatValue) string
+	numberType  d2stats.StatNumberType
+	combineType d2stats.ValueCombineType
 }
 
-// Type returns the stat value type
-func (sv *Diablo2StatValue) Type() d2stats.StatValueType {
-	return sv._type
+// NumberType returns the stat value type
+func (sv *Diablo2StatValue) NumberType() d2stats.StatNumberType {
+	return sv.numberType
+}
+
+// CombineType returns the stat value combination type
+func (sv *Diablo2StatValue) CombineType() d2stats.ValueCombineType {
+	return sv.combineType
 }
 
 // Clone returns a deep copy of the stat value
 func (sv Diablo2StatValue) Clone() d2stats.StatValue {
 	clone := &Diablo2StatValue{}
 
-	switch sv._type {
+	switch sv.numberType {
 	case d2stats.StatValueInt:
 		clone.SetInt(sv.Int())
 	case d2stats.StatValueFloat:
 		clone.SetFloat(sv.Float())
 	}
 
-	clone._stringer = sv._stringer
+	clone.stringerFn = sv.stringerFn
 
 	return clone
 }
@@ -42,7 +48,7 @@ func (sv *Diablo2StatValue) Int() int {
 
 // String returns a string version of the value
 func (sv *Diablo2StatValue) String() string {
-	return sv._stringer(sv)
+	return sv.stringerFn(sv)
 }
 
 // Float returns a float64 version of the value
@@ -66,11 +72,11 @@ func (sv *Diablo2StatValue) SetFloat(f float64) d2stats.StatValue {
 
 // Stringer returns the string evaluation function
 func (sv *Diablo2StatValue) Stringer() func(d2stats.StatValue) string {
-	return sv._stringer
+	return sv.stringerFn
 }
 
 // SetStringer sets the string evaluation function
 func (sv *Diablo2StatValue) SetStringer(f func(d2stats.StatValue) string) d2stats.StatValue {
-	sv._stringer = f
+	sv.stringerFn = f
 	return sv
 }

--- a/d2core/d2stats/diablo2stats/statlist.go
+++ b/d2core/d2stats/diablo2stats/statlist.go
@@ -4,7 +4,7 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2stats"
 )
 
-// static check that Diablo2Stat implements Stat
+// static check that diablo2Stat implements Stat
 var _ d2stats.StatList = &Diablo2StatList{}
 
 // Diablo2StatList is a diablo 2 implementation of a stat list

--- a/d2core/d2stats/diablo2stats/statlist_test.go
+++ b/d2core/d2stats/diablo2stats/statlist_test.go
@@ -3,13 +3,11 @@ package diablo2stats
 import (
 	"testing"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2data/d2datadict"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2stats"
 )
 
 func TestDiablo2StatList_Index(t *testing.T) {
-	record := d2datadict.ItemStatCosts["strength"]
-	strength := NewStat(record, intVal(10))
+	strength := NewStat("strength", 10)
 
 	list1 := &Diablo2StatList{stats: []d2stats.Stat{strength}}
 	if list1.Index(0) != strength {
@@ -18,8 +16,7 @@ func TestDiablo2StatList_Index(t *testing.T) {
 }
 
 func TestStatList_Clone(t *testing.T) {
-	record := d2datadict.ItemStatCosts["strength"]
-	strength := NewStat(record, intVal(10))
+	strength := NewStat("strength", 10)
 
 	list1 := &Diablo2StatList{}
 	list1.Push(strength)
@@ -40,56 +37,42 @@ func TestStatList_Clone(t *testing.T) {
 }
 
 func TestStatList_Reduce(t *testing.T) {
-	records := []*d2datadict.ItemStatCostRecord{
-		d2datadict.ItemStatCosts["strength"],
-		d2datadict.ItemStatCosts["energy"],
-		d2datadict.ItemStatCosts["dexterity"],
-		d2datadict.ItemStatCosts["vitality"],
-	}
-
 	stats := []d2stats.Stat{
-		NewStat(records[0], intVal(1)),
-		NewStat(records[0], intVal(1)),
-		NewStat(records[0], intVal(1)),
-		NewStat(records[0], intVal(1)),
+		NewStat("strength", 1),
+		NewStat("strength", 1),
+		NewStat("strength", 1),
+		NewStat("strength", 1),
 	}
 
 	list := NewStatList(stats...)
 	reduction := list.ReduceStats()
 
 	if len(reduction.Stats()) != 1 || reduction.Index(0).String() != "+4 to Strength" {
-		t.Errorf("Diablo2Stat reduction failed")
+		t.Errorf("diablo2Stat reduction failed")
 	}
 
 	stats = []d2stats.Stat{
-		NewStat(records[0], intVal(1)),
-		NewStat(records[1], intVal(1)),
-		NewStat(records[2], intVal(1)),
-		NewStat(records[3], intVal(1)),
+		NewStat("strength", 1),
+		NewStat("energy", 1),
+		NewStat("dexterity", 1),
+		NewStat("vitality", 1),
 	}
 
 	list = NewStatList(stats...)
 	reduction = list.ReduceStats()
 
 	if len(reduction.Stats()) != 4 {
-		t.Errorf("Diablo2Stat reduction failed")
+		t.Errorf("diablo2Stat reduction failed")
 	}
 }
 
 func TestStatList_Append(t *testing.T) {
-	records := []*d2datadict.ItemStatCostRecord{
-		d2datadict.ItemStatCosts["strength"],
-		d2datadict.ItemStatCosts["energy"],
-		d2datadict.ItemStatCosts["dexterity"],
-		d2datadict.ItemStatCosts["vitality"],
-	}
-
 	list1 := &Diablo2StatList{
 		[]d2stats.Stat{
-			NewStat(records[0], intVal(1)),
-			NewStat(records[1], intVal(1)),
-			NewStat(records[2], intVal(1)),
-			NewStat(records[3], intVal(1)),
+			NewStat("strength", 1),
+			NewStat("energy", 1),
+			NewStat("dexterity", 1),
+			NewStat("vitality", 1),
 		},
 	}
 	list2 := list1.Clone()
@@ -97,10 +80,10 @@ func TestStatList_Append(t *testing.T) {
 	list3 := list1.AppendStatList(list2)
 
 	if len(list3.Stats()) != 8 {
-		t.Errorf("Diablo2Stat append failed")
+		t.Errorf("diablo2Stat append failed")
 	}
 
 	if len(list3.ReduceStats().Stats()) != 4 {
-		t.Errorf("Diablo2Stat append failed")
+		t.Errorf("diablo2Stat append failed")
 	}
 }

--- a/d2core/d2stats/stat_value.go
+++ b/d2core/d2stats/stat_value.go
@@ -1,19 +1,51 @@
 package d2stats
 
-// StatValueType is a value type for a stat value
-type StatValueType int
+// StatNumberType is a value type for a stat value
+type StatNumberType int
 
 //  Stat value types
 const (
-	StatValueInt StatValueType = iota
+	StatValueInt StatNumberType = iota
 	StatValueFloat
+)
+
+// ValueCombineType is a rule for combining stat values
+type ValueCombineType int
+
+const (
+	// StatValueCombineSum means that the values are simply summed
+	StatValueCombineSum ValueCombineType = iota
+
+	// StatValueCombineStatic means that values can be combined only if they
+	// have the same number value, and that the combination does not alter
+	// the number value. This is typically for things like static skill level
+	// monster/skill index for on proc stats where it doesnt make sense to sum
+	// the values
+	// example 1:
+	//	if
+	//		Stat_A := `25% chance to cast level 2 Frozen Orb on attack`
+	//		Stat_B := `25% chance to cast level 3 Frozen Orb on attack`
+	// then
+	// 		Stat_A can NOT be combined with Stat_B
+	//		even though the skills are the same, the levels are different
+	//
+	// example 2:
+	//	if
+	//		Stat_A := `25% chance to cast level 20 Frost Nova on attack`
+	//		Stat_B := `25% chance to cast level 20 Frost Nova on attack`
+	// then
+	// 		the skills and skill levels are the same, so it can be combined
+	//		(Stat_A + Stat_B) == `50% chance to cast level 20 Frost Nova on attack`
+	StatValueCombineStatic
 )
 
 // StatValue is something that can have both integer and float
 // number components, as well as a means of retrieving a string for
 // its values.
 type StatValue interface {
-	Type() StatValueType
+	NumberType() StatNumberType
+	CombineType() ValueCombineType
+
 	Clone() StatValue
 
 	SetInt(int) StatValue


### PR DESCRIPTION
- simplified `NewStat` provider function
- added initializer for stat values that sets the stringer functions, value types, and combination types for values when created. `NewStat("strength",  2)` does what you think it will
- removed redundant description functions
- added stat value combination types `sum` and `static`

`static` stat values which are not altered when stats are combined. this makes sense for stats like proc-on-hit or +skills to class

**Example**:
- Stat A: `10% reanimate as: skeleton mage`
- Stat B: `8% reanimate as: skeleton archer`
- Stat C: `6% reanimate as: skeleton archer`

	A and B can not be combined
	B and C can be combined to `14% reanimate as: skeleton archer`