### PR TITLE
Add qualityitems.txt loader

### DIFF
--- a/d2app/app.go
+++ b/d2app/app.go
@@ -228,6 +228,7 @@ func (a *App) loadDataDict() error {
 		{d2resource.Hireling, d2datadict.LoadHireling},
 		{d2resource.Experience, d2datadict.LoadExperienceBreakpoints},
 		{d2resource.Gems, d2datadict.LoadGems},
+		{d2resource.QualityItems, d2datadict.LoadQualityItems},
 		{d2resource.DifficultyLevels, d2datadict.LoadDifficultyLevels},
 		{d2resource.AutoMap, d2datadict.LoadAutoMaps},
 		{d2resource.LevelDetails, d2datadict.LoadLevelDetails},

--- a/d2common/d2data/d2datadict/quality_items.go
+++ b/d2common/d2data/d2datadict/quality_items.go
@@ -1,0 +1,85 @@
+package d2datadict
+
+import (
+	"log"
+	"strconv"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common"
+)
+
+// QualityRecord represents a single row of QualityItems.txt, which controls
+// properties for superior quality items
+type QualityRecord struct {
+	NumMods   int
+	Mod1Code  string
+	Mod1Param int
+	Mod1Min   int
+	Mod1Max   int
+	Mod2Code  string
+	Mod2Param int
+	Mod2Min   int
+	Mod2Max   int
+
+	// The following fields determine this row's applicability to
+	// categories of item.
+	Armor   bool
+	Weapon  bool
+	Shield  bool
+	Thrown  bool
+	Scepter bool
+	Wand    bool
+	Staff   bool
+	Bow     bool
+	Boots   bool
+	Gloves  bool
+	Belt    bool
+
+	Level    int
+	Multiply int
+	Add      int
+}
+
+// QualityItems stores all of the QualityRecords
+var QualityItems map[string]*QualityRecord //nolint:gochecknoglobals // Currently global by design, only written once
+
+// LoadQualityItems loads QualityItem records into a map[string]*QualityRecord
+func LoadQualityItems(file []byte) {
+	QualityItems = make(map[string]*QualityRecord)
+
+	d := d2common.LoadDataDictionary(file)
+	for d.Next() {
+		qual := &QualityRecord{
+			NumMods:   d.Number("nummods"),
+			Mod1Code:  d.String("mod1code"),
+			Mod1Param: d.Number("mod1param"),
+			Mod1Min:   d.Number("mod1min"),
+			Mod1Max:   d.Number("mod1max"),
+			Mod2Code:  d.String("mod2code"),
+			Mod2Param: d.Number("mod2param"),
+			Mod2Min:   d.Number("mod2min"),
+			Mod2Max:   d.Number("mod2max"),
+			Armor:     d.Bool("armor"),
+			Weapon:    d.Bool("weapon"),
+			Shield:    d.Bool("shield"),
+			Thrown:    d.Bool("thrown"),
+			Scepter:   d.Bool("scepter"),
+			Wand:      d.Bool("wand"),
+			Staff:     d.Bool("staff"),
+			Bow:       d.Bool("bow"),
+			Boots:     d.Bool("boots"),
+			Gloves:    d.Bool("gloves"),
+			Belt:      d.Bool("belt"),
+			Level:     d.Number("level"),
+			Multiply:  d.Number("multiply"),
+			Add:       d.Number("add"),
+		}
+
+		QualityItems[strconv.Itoa(len(QualityItems))] = qual
+	}
+
+	if d.Err != nil {
+		panic(d.Err)
+	}
+
+	log.Printf("Loaded %d QualityItems records", len(QualityItems))
+}

--- a/d2common/d2resource/resource_paths.go
+++ b/d2common/d2resource/resource_paths.go
@@ -181,6 +181,7 @@ const (
 	SoundSettings    = "/data/global/excel/Sounds.txt"
 	ItemStatCost     = "/data/global/excel/ItemStatCost.txt"
 	ItemTypes        = "/data/global/excel/ItemTypes.txt"
+	QualityItems     = "/data/global/excel/qualityitems.txt"
 	Sets             = "/data/global/excel/Sets.txt"
 	SetItems         = "/data/global/excel/SetItems.txt"
 	AutoMagic        = "/data/global/excel/automagic.txt"


### PR DESCRIPTION
> GravestenchToday at 8:54 AM
> @Sheep data loaders for the txt files
> refer to this page: https://d2mods.info/forum/kb/index?c=4
> look at gems.go or itemstatcost.go for an example of how we are currently loading txt file data (other loaders need to be updated)
> those can be found in d2common/d2data/d2datadict/
> i am currently working on adding loaders for ItemTypes.txt, Sets.txt, SetItems.txt, AutoMagic.txt, and bodylocs.txt because I'm trying to work on items and I need those
> implement a different loader, please

I cribbed from gems for this one.