### PR TITLE
Minor edit: unidentified items to use common item type name in label on mouse hover

### DIFF
--- a/d2core/d2item/diablo2item/item.go
+++ b/d2core/d2item/diablo2item/item.go
@@ -112,6 +112,10 @@ type minMaxEnhanceable struct {
 func (i *Item) Label() string {
 	str := i.name
 
+	if !i.attributes.identitified {
+		str = d2common.TranslateString(i.CommonRecord().NameString)
+	}
+
 	if i.attributes.crafted {
 		return d2ui.ColorTokenize(str, d2ui.ColorTokenCraftedItem)
 	}


### PR DESCRIPTION
unidentified items should use common record name for label