### PR TITLE
add rare prefix+suffix loaders, d2items use rare item names

### DIFF
--- a/d2app/app.go
+++ b/d2app/app.go
@@ -289,6 +289,8 @@ func (a *App) loadDataDict() error {
 		{d2resource.ObjectGroup, d2datadict.LoadObjectGroups},
 		{d2resource.CompCode, d2datadict.LoadComponentCodes},
 		{d2resource.MonsterAI, d2datadict.LoadMonsterAI},
+		{d2resource.RarePrefix, d2datadict.LoadRareItemPrefixRecords},
+		{d2resource.RareSuffix, d2datadict.LoadRareItemSuffixRecords},
 	}
 
 	d2datadict.InitObjectRecords()

--- a/d2common/d2data/d2datadict/rare_prefix.go
+++ b/d2common/d2data/d2datadict/rare_prefix.go
@@ -23,13 +23,13 @@ type RareItemPrefixRecord struct {
 }
 
 // RarePrefixes is where all RareItemPrefixRecords are stored
-var RarePrefixes map[string]*RareItemPrefixRecord // nolint:gochecknoglobals // global by design
+var RarePrefixes []*RareItemPrefixRecord // nolint:gochecknoglobals // global by design
 
 // LoadRareItemPrefixRecords loads the rare item prefix records from rareprefix.txt
 func LoadRareItemPrefixRecords(file []byte) {
 	d := d2common.LoadDataDictionary(file)
 
-	RarePrefixes = make(map[string]*RareItemPrefixRecord)
+	RarePrefixes = make([]*RareItemPrefixRecord, 0)
 
 	for d.Next() {
 		record := &RareItemPrefixRecord{
@@ -52,7 +52,7 @@ func LoadRareItemPrefixRecords(file []byte) {
 			}
 		}
 
-		RarePrefixes[record.Name] = record
+		RarePrefixes = append(RarePrefixes, record)
 	}
 
 	log.Printf("Loaded %d RarePrefix records", len(RarePrefixes))

--- a/d2common/d2data/d2datadict/rare_prefix.go
+++ b/d2common/d2data/d2datadict/rare_prefix.go
@@ -1,0 +1,59 @@
+package d2datadict
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common"
+)
+
+const (
+	numRarePrefixInclude = 7
+	fmtRarePrefixInclude = "itype%d"
+
+	numRarePrefixExclude = 4
+	fmtRarePrefixExclude = "etype%d"
+)
+
+// RareItemPrefixRecord is a name prefix for rare items (items with more than 2 affixes)
+type RareItemPrefixRecord struct {
+	Name          string
+	IncludedTypes []string
+	ExcludedTypes []string
+}
+
+// RarePrefixes is where all RareItemPrefixRecords are stored
+var RarePrefixes map[string]*RareItemPrefixRecord // nolint:gochecknoglobals // global by design
+
+// LoadRareItemPrefixRecords loads the rare item prefix records from rareprefix.txt
+func LoadRareItemPrefixRecords(file []byte) {
+	d := d2common.LoadDataDictionary(file)
+
+	RarePrefixes = make(map[string]*RareItemPrefixRecord)
+
+	for d.Next() {
+		record := &RareItemPrefixRecord{
+			Name:          d.String("name"),
+			IncludedTypes: make([]string, 0),
+			ExcludedTypes: make([]string, 0),
+		}
+
+		for idx := 1; idx <= numRarePrefixInclude; idx++ {
+			column := fmt.Sprintf(fmtRarePrefixInclude, idx)
+			if typeCode := d.String(column); typeCode != "" {
+				record.IncludedTypes = append(record.IncludedTypes, typeCode)
+			}
+		}
+
+		for idx := 1; idx <= numRarePrefixExclude; idx++ {
+			column := fmt.Sprintf(fmtRarePrefixExclude, idx)
+			if typeCode := d.String(column); typeCode != "" {
+				record.ExcludedTypes = append(record.ExcludedTypes, typeCode)
+			}
+		}
+
+		RarePrefixes[record.Name] = record
+	}
+
+	log.Printf("Loaded %d RarePrefix records", len(RarePrefixes))
+}

--- a/d2common/d2data/d2datadict/rare_suffix.go
+++ b/d2common/d2data/d2datadict/rare_suffix.go
@@ -23,13 +23,13 @@ type RareItemSuffixRecord struct {
 }
 
 // RareSuffixes is where all RareItemSuffixRecords are stored
-var RareSuffixes map[string]*RareItemSuffixRecord // nolint:gochecknoglobals // global by design
+var RareSuffixes []*RareItemSuffixRecord // nolint:gochecknoglobals // global by design
 
 // LoadRareItemSuffixRecords loads the rare item suffix records from raresuffix.txt
 func LoadRareItemSuffixRecords(file []byte) {
 	d := d2common.LoadDataDictionary(file)
 
-	RareSuffixes = make(map[string]*RareItemSuffixRecord)
+	RareSuffixes = make([]*RareItemSuffixRecord, 0)
 
 	for d.Next() {
 		record := &RareItemSuffixRecord{
@@ -52,7 +52,7 @@ func LoadRareItemSuffixRecords(file []byte) {
 			}
 		}
 
-		RareSuffixes[record.Name] = record
+		RareSuffixes = append(RareSuffixes, record)
 	}
 
 	log.Printf("Loaded %d RareSuffix records", len(RareSuffixes))

--- a/d2common/d2data/d2datadict/rare_suffix.go
+++ b/d2common/d2data/d2datadict/rare_suffix.go
@@ -1,0 +1,59 @@
+package d2datadict
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common"
+)
+
+const (
+	numRareSuffixInclude = 7
+	fmtRareSuffixInclude = "itype%d"
+
+	numRareSuffixExclude = 4
+	fmtRareSuffixExclude = "etype%d"
+)
+
+// RareItemSuffixRecord is a name suffix for rare items (items with more than 2 affixes)
+type RareItemSuffixRecord struct {
+	Name          string
+	IncludedTypes []string
+	ExcludedTypes []string
+}
+
+// RareSuffixes is where all RareItemSuffixRecords are stored
+var RareSuffixes map[string]*RareItemSuffixRecord // nolint:gochecknoglobals // global by design
+
+// LoadRareItemSuffixRecords loads the rare item suffix records from raresuffix.txt
+func LoadRareItemSuffixRecords(file []byte) {
+	d := d2common.LoadDataDictionary(file)
+
+	RareSuffixes = make(map[string]*RareItemSuffixRecord)
+
+	for d.Next() {
+		record := &RareItemSuffixRecord{
+			Name:          d.String("name"),
+			IncludedTypes: make([]string, 0),
+			ExcludedTypes: make([]string, 0),
+		}
+
+		for idx := 1; idx <= numRareSuffixInclude; idx++ {
+			column := fmt.Sprintf(fmtRareSuffixInclude, idx)
+			if typeCode := d.String(column); typeCode != "" {
+				record.IncludedTypes = append(record.IncludedTypes, typeCode)
+			}
+		}
+
+		for idx := 1; idx <= numRareSuffixExclude; idx++ {
+			column := fmt.Sprintf(fmtRareSuffixExclude, idx)
+			if typeCode := d.String(column); typeCode != "" {
+				record.ExcludedTypes = append(record.ExcludedTypes, typeCode)
+			}
+		}
+
+		RareSuffixes[record.Name] = record
+	}
+
+	log.Printf("Loaded %d RareSuffix records", len(RareSuffixes))
+}

--- a/d2common/d2resource/resource_paths.go
+++ b/d2common/d2resource/resource_paths.go
@@ -241,11 +241,10 @@ const (
 
 	MagicPrefix = "/data/global/excel/MagicPrefix.txt"
 	MagicSuffix = "/data/global/excel/MagicSuffix.txt"
+	RarePrefix   = "/data/global/excel/RarePrefix.txt" // these are for item names
+	RareSuffix   = "/data/global/excel/RareSuffix.txt"
 
 	// --- Monster Prefix/Suffixes (?) ---
-
-	RarePrefix   = "/data/global/excel/RarePrefix.txt"
-	RareSuffix   = "/data/global/excel/RareSuffix.txt"
 	UniquePrefix = "/data/global/excel/UniquePrefix.txt"
 	UniqueSuffix = "/data/global/excel/UniqueSuffix.txt"
 


### PR DESCRIPTION
Unlike magic items (items with 1 to 2 affixes), a rare item (3 or more affixes) does not use the affixes for the display name. Instead, a random `RarePrefix` and random `RareSuffix` is chosen.

![image](https://user-images.githubusercontent.com/936440/89600784-b02fee00-d817-11ea-9832-882a708044be.png)
