### PR TITLE
Example of a data loader using reflection.

### DIFF
--- a/d2common/d2data/d2datadict/books.go
+++ b/d2common/d2data/d2datadict/books.go
@@ -1,7 +1,9 @@
 package d2datadict
 
 import (
+	"fmt"
 	"log"
+	"reflect"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common"
 )
@@ -13,7 +15,7 @@ type BooksRecord struct {
 	Completed       string
 	ScrollSpellCode string
 	BookSpellCode   string
-	pSpell          int
+	PSpell          int
 	SpellIcon       int
 	ScrollSkill     string
 	BookSkill       string
@@ -29,21 +31,14 @@ func LoadBooks(file []byte) {
 	Books = make(map[string]*BooksRecord)
 
 	d := d2common.LoadDataDictionary(file)
+
 	for d.Next() {
-		record := &BooksRecord{
-			Name:            d.String("Name"),
-			Namco:           d.String("Namco"),
-			Completed:       d.String("Completed"),
-			ScrollSpellCode: d.String("ScrollSpellCode"),
-			BookSpellCode:   d.String("BooksSpellCode"),
-			pSpell:          d.Number("pSpell"),
-			SpellIcon:       d.Number("SpellIcon"),
-			ScrollSkill:     d.String("ScrollSkill"),
-			BookSkill:       d.String("BookSkill"),
-			BaseCost:        d.Number("BaseCost"),
-			CostPerCharge:   d.Number("CostPerCharge"),
+		record := BooksRecord{}
+		err := d.PopulateStruct(reflect.ValueOf(&record).Elem())
+		if err != nil {
+			fmt.Println(err)
 		}
-		Books[record.Namco] = record
+		Books[record.Namco] = &record
 	}
 
 	if d.Err != nil {


### PR DESCRIPTION
This PR is intended as an example for something I discussed with @gravestench. Not sure why it can't be automatically merged but it probably shouldn't be merged at all so no biggie.

The PopulateStruct function works as a 'generic' way to fill a struct with some data in a map. The struct must be defined and passed to reflect.ValueOf(), but no specific code is required to fill that struct. The return value of `reflect.ValueOf()` gives us the parameter `values reflect.Value` which represents any struct we want to populate, as something resembling a map of field names and values. The only code that must run for the specific type is:

`record := BooksRecord{}`
`err := d.PopulateStruct(reflect.ValueOf(&record).Elem())`
`Books[record.Namco] = &record`

There is another implementation [here](https://github.com/danhale-git/runrdp/blob/2293cdccf7d7eff021dbb34ac27e898848070a2e/internal/config/config.go#L184) which covers more types.

That implementation was my first attempt at using reflection in Go. I don't know about the performance implications of using it for all data loading, there probably are some.

I've just quickly shoe-horned this into the existing books loader. No doubt it could be used to clean up the code much more than I have, if it is viable.