### PR TITLE
unbinds the character select screen after use

### DIFF
--- a/d2game/d2gamescreen/character_select.go
+++ b/d2game/d2gamescreen/character_select.go
@@ -502,3 +502,11 @@ func (v *CharacterSelect) refreshGameStates() {
 func (v *CharacterSelect) onOkButtonClicked() {
 	v.navigator.ToCreateGame(v.gameStates[v.selectedCharacter].FilePath, v.connectionType, v.connectionHost)
 }
+
+func (v *CharacterSelect) OnUnload() error {
+	if err := v.inputManager.UnbindHandler(v); err != nil { // TODO: hack
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Apparently SOMEONE didn't unbind the character screen when it closes out, which meant the game would check all the events while in the actual game.

Definitely wasn't me.

(This adds the unbind function.)

Thanks to @gravestench for the code and bug fix.