### PR TITLE
Introductory notes for OS X

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ go_install(){
 	  	sudo tar -C /usr/local -xzf go*.linux-amd64.tar.gz > /dev/null 2>&1
       echo "Clean unneeded files"
 	  	rm go*.linux-amd64.tar.gz
-      
+
     elif [ "$distribution" = "Fedora" ]; then
       echo "Downloading Go"
       wget https://dl.google.com/go/go"$go_version".linux-amd64.tar.gz > /dev/null 2>&1
@@ -41,7 +41,7 @@ go_install(){
 	    sudo tar -C /usr/local -xzf go*.linux-amd64.tar.gz > /dev/null 2>&1
       echo "Clean unneeded files"
 	    rm go*.linux-amd64.tar.gz
-    
+
     elif [ "$distribution" = "Debian" ] || [ "$distribution" = "Ubuntu" ] || [ "$distribution" = "Deepin" ]; then
       echo "Downloading Go"
       wget https://dl.google.com/go/go"$go_version".linux-amd64.tar.gz > /dev/null 2>&1
@@ -49,13 +49,13 @@ go_install(){
 	    sudo tar -C /usr/local -xzf go*.linux-amd64.tar.gz > /dev/null 2>&1
       echo "Clean unneeded files"
 	    rm go*.linux-amd64.tar.gz
-      
+
     elif [ "$distribution" = "Gentoo" ]; then
       sudo emerge --ask n go
-      
+
     elif [ "$distribution" = "Manjaro" ] || [ "$distribution" = "Arch\ Linux" ]; then
       sudo pacman -S go --noconfirm
-	  
+
 	elif [ "$distribution" = "OpenSUSE" ] || [ "$distribution" = "SUSE" ]; then
 	  echo "Downloading Go"
       wget https://dl.google.com/go/go"$go_version".linux-amd64.tar.gz > /dev/null 2>&1
@@ -71,26 +71,30 @@ fi
 dep_install(){
 	  if [ "$distribution" = "CentOS" ] || [ "$distribution" = "Red\ Hat" ] || [ "$distribution" = "Oracle" ]; then
 	  sudo yum install -y libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel mesa-libGL-devel alsa-lib-devel libXi-devel > /dev/null 2>&1
-		
+
     elif [ "$distribution" = "Fedora" ]; then
 	  sudo dnf install -y libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel mesa-libGL-devel alsa-lib-devel libXi-devel > /dev/null 2>&1
-		
+
     elif [ "$distribution" = "Debian" ] || [ "$distribution" = "Ubuntu" ] || [ "$distribution" = "Deepin" ]; then
 	  sudo apt-get install -y libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libgl1-mesa-dev libsdl2-dev libasound2-dev > /dev/null 2>&1
-		
+
     elif [ "$distribution" = "Gentoo" ]; then
     sudo emerge --ask n libXcursor libXrandr libXinerama libXi libGLw libglvnd libsdl2 alsa-lib > /dev/null 2>&1
-		
+
     elif [ "$distribution" = "Manjaro" ] || [ "$distribution" = "Arch\ Linux" ]; then
 
-    if [ -z "$mesa_detect_arch" ]; then
-		sudo pacman -S libxcursor libxrandr libxinerama libxi mesa libglvnd sdl2 sdl2_mixer sdl2_net alsa-lib --noconfirm > /dev/null 2>&1
-    else
-    sudo pacman -S libxcursor libxrandr libxinerama libxi libglvnd sdl2 sdl2_mixer sdl2_net alsa-lib --noconfirm > /dev/null 2>&1
-    fi
+      if [ -z "$mesa_detect_arch" ]; then
+  		sudo pacman -S libxcursor libxrandr libxinerama libxi mesa libglvnd sdl2 sdl2_mixer sdl2_net alsa-lib --noconfirm > /dev/null 2>&1
+      else
+      sudo pacman -S libxcursor libxrandr libxinerama libxi libglvnd sdl2 sdl2_mixer sdl2_net alsa-lib --noconfirm > /dev/null 2>&1
+      fi
 
 	  elif [ "$distribution" = "OpenSUSE" ] || [ "$distribution" = "SUSE" ]; then
 		sudo zypper install -y libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel Mesa-libGL-devel alsa-lib-devel libXi-devel > /dev/null 2>&1
+
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # are there dependencies required? did I just have all of them already?
+    echo "Mac OS detected, no dependency installation necessary..."
 
     fi
 }
@@ -108,4 +112,5 @@ fi
 echo "Build OpenDiablo 2"
 go get -d
 go build
-echo "Build finished. Please edit config.json before running OpenDiablo2"
+echo "Build finished. Running OpenDiablo2 will generate a config.json file."
+echo "If there are subsequent errors, please inspect and edit the config.json file. See doc/index.html for more details"

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
 	<hr />
 	<h2 id="config">Configuration</h2>
 	<div class="paragraph">
-	<span>There is a configuration file (config.json) that should be located in the root folder. The following table describes the different options and what they mean.</span>
+	<span>There is a configuration file (config.json) whose location depends on your operating system. It will be generated when OpenDiablo2 is run and the output will show the file location for editing. The following table describes the different options and what they mean.</span>
 		<table>
 			<thead>
 			<tr>


### PR DESCRIPTION
The process for getting started as a contributor on OS X is a bit confusing. This PR takes a tiny stab at that problem.

- At first, I saw that `build.sh` had no section for darwin, which originally led me to believe it would not run on OS X at all and I'd have a big slog ahead of me to even get started. This turned out not to be the case, but I almost didn't even try. I'm not sure if I already have the dependencies or if they come on default on OS X. I certainly already had `go` setup so I did not bother with the `go_install` section yet.
- There are references to `config.json`, but this file doesn't actually exist until you try to run OD2. And even then, it isn't in the root directory like the docs claim (at least on OS X). Because I'm using Bootcamp to load MPQ files from my Windows partition, I had to edit this file. Updated the docs to better reference the current state of config.json