### PR TITLE
Added an OnKeyUp method to the main menu to emulate retail behaviour

### DIFF
--- a/d2game/d2gamescreen/main_menu.go
+++ b/d2game/d2gamescreen/main_menu.go
@@ -521,6 +521,21 @@ func (v *MainMenu) OnMouseButtonDown(event d2interface.MouseEvent) bool {
 	return false
 }
 
+// OnKeyUp is called when a key is released
+func (v *MainMenu) OnKeyUp(event d2interface.KeyEvent) bool {
+	/*
+		On retail version of D2 any key event puts you onto the main menu, so this is a supplement to that code up there
+		on line 515.
+	*/
+
+	if v.screenMode == ScreenModeTrademark {
+		v.SetScreenMode(ScreenModeMainMenu)
+		return true
+	}
+
+	return false
+}
+
 // SetScreenMode sets the screen mode (which sub-menu the screen is on)
 func (v *MainMenu) SetScreenMode(screenMode mainMenuScreenMode) {
 	v.screenMode = screenMode


### PR DESCRIPTION
On the title screen on a retail copy of D2 you can press any key on the keyboard and it will take you to the main menu, I have added this functionality to OpenDiablo2