### PR TITLE
Animation mode for player should be checked (and possible changed) every tick.

### DIFF
--- a/d2core/d2map/d2mapentity/player.go
+++ b/d2core/d2map/d2mapentity/player.go
@@ -87,12 +87,13 @@ const (
 func (p *Player) Advance(tickTime float64) {
 	p.Step(tickTime)
 
+	if err := p.SetAnimationMode(p.GetAnimationMode()); err != nil {
+		fmt.Printf("failed to set animationMode to: %d, err: %v\n", p.GetAnimationMode(), err)
+	}
+
 	if p.IsCasting() {
 		if p.composite.GetPlayedCount() >= 1 {
 			p.isCasting = false
-			if err := p.SetAnimationMode(p.GetAnimationMode()); err != nil {
-				fmt.Printf("failed to set animationMode to: %d, err: %v\n", p.GetAnimationMode(), err)
-			}
 		}
 
 		// skills are casted after the first half of the casting animation is played


### PR DESCRIPTION
Animation mode needs to be changed when the player stops or starts running while following a path (single click, don't hold the mouse at target). Fixes #837

I could not find any problems with animations which do not work anymore after this change, also the casting does still work.