### PR TITLE
Health/Mana/Exp load values from save file #815

### DIFF
--- a/d2core/d2hero/hero_stats_state.go
+++ b/d2core/d2hero/hero_stats_state.go
@@ -55,10 +55,5 @@ func (f *HeroStateFactory) CreateHeroStatsState(heroClass d2enum.Hero, classStat
 	result.Health = result.MaxHealth
 	result.Stamina = float64(result.MaxStamina)
 
-	// https://github.com/OpenDiablo2/OpenDiablo2/issues/815
-	result.Health = 50
-	result.Mana = 30
-	result.Experience = 166
-
 	return &result
 }

--- a/d2core/d2map/d2mapentity/factory.go
+++ b/d2core/d2map/d2mapentity/factory.go
@@ -85,9 +85,7 @@ func (f *MapEntityFactory) NewPlayer(id, name string, x, y, direction int, heroT
 	stats.NextLevelExp = f.asset.Records.GetExperienceBreakpoint(heroType, stats.Level)
 	stats.Stamina = float64(stats.MaxStamina)
 
-	defaultCharStats := f.asset.Records.Character.Stats[heroType]
-	statsState := f.HeroStateFactory.CreateHeroStatsState(heroType, defaultCharStats)
-	heroState, _ := f.CreateHeroState(name, heroType, statsState)
+	heroState, _ := f.CreateHeroState(name, heroType, stats)
 
 	attackSkillID := 0
 	result := &Player{


### PR DESCRIPTION
Characters now Health/Mana/Exp from save files and no longer use defaults. New characters receive the default values of MaxHealth/MaxMana/0xp respectively. This does not address the ability to save, I will submit a new PR for this.