### PR TITLE
d2gamescreen/char_select: Fix crash on double clicking singleplayer

### DIFF
--- a/d2game/d2gamescreen/character_select.go
+++ b/d2game/d2gamescreen/character_select.go
@@ -47,6 +47,7 @@ type CharacterSelect struct {
 	tickTimer              float64
 	storedTickTimer        float64
 	showDeleteConfirmation bool
+	loaded                 bool
 	connectionType         d2clientconnectiontype.ClientConnectionType
 	connectionHost         string
 
@@ -195,6 +196,7 @@ func (v *CharacterSelect) OnLoad(loading d2screen.LoadingState) {
 	}
 
 	v.refreshGameStates()
+	v.loaded = true
 }
 
 func (v *CharacterSelect) loadBackground() {
@@ -429,6 +431,10 @@ func (v *CharacterSelect) moveSelectionBox() {
 
 // OnMouseButtonDown is called when a mouse button is clicked
 func (v *CharacterSelect) OnMouseButtonDown(event d2interface.MouseEvent) bool {
+	if !v.loaded {
+		return false
+	}
+
 	if v.showDeleteConfirmation {
 		return false
 	}
@@ -554,6 +560,8 @@ func (v *CharacterSelect) OnUnload() error {
 	if err := v.inputManager.UnbindHandler(v); err != nil {
 		return err
 	}
+
+	v.loaded = false
 
 	return nil
 }


### PR DESCRIPTION
if we clicked twice on the single player button of the main menu, then
the first click would set the current screen to the
character_select. The second click directly after that will be
handled by the character_select screen. It's OnLoad() method was not
called yet, which initialized all widgets. The click handler of
character_select screen referenced the nil scrollbar and crashes.