### PR TITLE
Ui panel refactor part 2

### DIFF
--- a/d2core/d2ui/custom_widget.go
+++ b/d2core/d2ui/custom_widget.go
@@ -42,7 +42,9 @@ func (ui *UIManager) NewCustomWidget(renderFunc func(target d2interface.Surface)
 // Render draws the custom widget
 func (c *CustomWidget) Render(target d2interface.Surface) {
 	if c.cached {
+		target.PushTranslation(c.GetPosition())
 		target.Render(*c.cachedImg)
+		target.Pop()
 	} else {
 		c.renderFunc(target)
 	}

--- a/d2core/d2ui/custom_widget.go
+++ b/d2core/d2ui/custom_widget.go
@@ -16,7 +16,7 @@ type CustomWidget struct {
 // NewCustomWidgetCached creates a new widget and caches anything rendered via the
 // renderFunc into a static image to be displayed
 func (ui *UIManager) NewCustomWidgetCached(renderFunc func(target d2interface.Surface), width, height int) *CustomWidget {
-	c := ui.NewCustomWidget(renderFunc)
+	c := ui.NewCustomWidget(renderFunc, width, height)
 	c.cached = true
 
 	// render using the renderFunc to a cache
@@ -28,8 +28,10 @@ func (ui *UIManager) NewCustomWidgetCached(renderFunc func(target d2interface.Su
 }
 
 // NewCustomWidget creates a new widget with custom render function
-func (ui *UIManager) NewCustomWidget(renderFunc func(target d2interface.Surface)) *CustomWidget {
+func (ui *UIManager) NewCustomWidget(renderFunc func(target d2interface.Surface), width, height int) *CustomWidget {
 	base := NewBaseWidget(ui)
+	base.width = width
+	base.height = height
 
 	return &CustomWidget{
 		BaseWidget: base,

--- a/d2core/d2ui/ui_manager.go
+++ b/d2core/d2ui/ui_manager.go
@@ -54,8 +54,9 @@ func (ui *UIManager) Reset() {
 // addWidgetGroup adds a widgetGroup to the UI manager and sorts by priority
 func (ui *UIManager) addWidgetGroup(group *WidgetGroup) {
 	ui.widgetsGroups = append(ui.widgetsGroups, group)
+
 	sort.SliceStable(ui.widgetsGroups, func(i, j int) bool {
-		return ui.widgetsGroups[i].priority < ui.widgetsGroups[j].priority
+		return ui.widgetsGroups[i].renderPriority < ui.widgetsGroups[j].renderPriority
 	})
 }
 

--- a/d2core/d2ui/ui_manager.go
+++ b/d2core/d2ui/ui_manager.go
@@ -97,6 +97,17 @@ func (ui *UIManager) OnMouseButtonUp(event d2interface.MouseEvent) bool {
 	return false
 }
 
+// OnMouseMove is the mouse move event handler
+func (ui *UIManager) OnMouseMove(event d2interface.MouseMoveEvent) bool {
+	for _, w := range ui.widgetsGroups {
+		if w.GetVisible() {
+			w.OnMouseMove(event.X(), event.Y())
+		}
+	}
+
+	return false
+}
+
 // OnMouseButtonDown is the mouse button down event handler
 func (ui *UIManager) OnMouseButtonDown(event d2interface.MouseEvent) bool {
 	ui.CursorX, ui.CursorY = event.X(), event.Y()

--- a/d2core/d2ui/ui_manager.go
+++ b/d2core/d2ui/ui_manager.go
@@ -84,7 +84,7 @@ func (ui *UIManager) OnMouseButtonUp(event d2interface.MouseEvent) bool {
 		// activate previously pressed widget if cursor is still hovering
 		w := ui.pressedWidget
 
-		if w != nil && ui.contains(w, ui.CursorX, ui.CursorY) && w.GetVisible() && w.GetEnabled() {
+		if w != nil && w.Contains(ui.CursorX, ui.CursorY) && w.GetVisible() && w.GetEnabled() {
 			w.Activate()
 		}
 
@@ -104,7 +104,7 @@ func (ui *UIManager) OnMouseButtonDown(event d2interface.MouseEvent) bool {
 		// find and press a widget on screen
 		ui.pressedWidget = nil
 		for _, w := range ui.clickableWidgets {
-			if ui.contains(w, ui.CursorX, ui.CursorY) && w.GetVisible() && w.GetEnabled() {
+			if w.Contains(ui.CursorX, ui.CursorY) && w.GetVisible() && w.GetEnabled() {
 				w.SetPressed(true)
 				ui.pressedWidget = w
 				ui.clickSfx.Play()
@@ -134,14 +134,6 @@ func (ui *UIManager) Render(target d2interface.Surface) {
 			widgetGroup.Render(target)
 		}
 	}
-}
-
-// contains determines whether a given x,y coordinate lands within a Widget
-func (ui *UIManager) contains(w Widget, x, y int) bool {
-	wx, wy := w.GetPosition()
-	ww, wh := w.GetSize()
-
-	return x >= wx && x <= wx+ww && y >= wy && y <= wy+wh
 }
 
 // Advance updates all of the UI elements

--- a/d2core/d2ui/widget.go
+++ b/d2core/d2ui/widget.go
@@ -21,6 +21,7 @@ const (
 type Widget interface {
 	Drawable
 	bindManager(ui *UIManager)
+	GetManager() (ui *UIManager)
 	OnHoverStart(callback func())
 	OnHoverEnd(callback func())
 	isHovered() bool
@@ -149,4 +150,9 @@ func (b *BaseWidget) Contains(x, y int) bool {
 	ww, wh := b.GetSize()
 
 	return x >= wx && x <= wx+ww && y >= wy && y <= wy+wh
+}
+
+// GetManager returns the uiManager
+func (b *BaseWidget) GetManager() (ui *UIManager) {
+	return b.manager
 }

--- a/d2core/d2ui/widget.go
+++ b/d2core/d2ui/widget.go
@@ -21,6 +21,11 @@ const (
 type Widget interface {
 	Drawable
 	bindManager(ui *UIManager)
+	OnHoverStart(callback func())
+	OnHoverEnd(callback func())
+	isHovered() bool
+	hoverStart()
+	hoverEnd()
 	Contains(x, y int) (contained bool)
 }
 
@@ -44,6 +49,10 @@ type BaseWidget struct {
 	height         int
 	renderPriority RenderPriority
 	visible        bool
+
+	hovered        bool
+	onHoverStartCb func()
+	onHoverEndCb   func()
 }
 
 // NewBaseWidget creates a new BaseWidget with defaults
@@ -102,6 +111,36 @@ func (b *BaseWidget) GetRenderPriority() (prio RenderPriority) {
 // SetRenderPriority sets the order in which this widget is rendered
 func (b *BaseWidget) SetRenderPriority(prio RenderPriority) {
 	b.renderPriority = prio
+}
+
+// OnHoverStart sets a function that is called if the hovering of the widget starts
+func (b *BaseWidget) OnHoverStart(callback func()) {
+	b.onHoverStartCb = callback
+}
+
+// HoverStart is called when the hovering of the widget starts
+func (b *BaseWidget) hoverStart() {
+	b.hovered = true
+	if b.onHoverStartCb != nil {
+		b.onHoverStartCb()
+	}
+}
+
+// OnHoverEnd sets a function that is called if the hovering of the widget ends
+func (b *BaseWidget) OnHoverEnd(callback func()) {
+	b.onHoverEndCb = callback
+}
+
+// hoverEnd is called when the widget hovering ends
+func (b *BaseWidget) hoverEnd() {
+	b.hovered = false
+	if b.onHoverEndCb != nil {
+		b.onHoverEndCb()
+	}
+}
+
+func (b *BaseWidget) isHovered() bool {
+	return b.hovered
 }
 
 // Contains determines whether a given x,y coordinate lands within a Widget

--- a/d2core/d2ui/widget.go
+++ b/d2core/d2ui/widget.go
@@ -21,6 +21,7 @@ const (
 type Widget interface {
 	Drawable
 	bindManager(ui *UIManager)
+	Contains(x, y int) (contained bool)
 }
 
 // ClickableWidget defines an object that can be clicked
@@ -101,4 +102,12 @@ func (b *BaseWidget) GetRenderPriority() (prio RenderPriority) {
 // SetRenderPriority sets the order in which this widget is rendered
 func (b *BaseWidget) SetRenderPriority(prio RenderPriority) {
 	b.renderPriority = prio
+}
+
+// Contains determines whether a given x,y coordinate lands within a Widget
+func (b *BaseWidget) Contains(x, y int) bool {
+	wx, wy := b.GetPosition()
+	ww, wh := b.GetSize()
+
+	return x >= wx && x <= wx+ww && y >= wy && y <= wy+wh
 }

--- a/d2core/d2ui/widget.go
+++ b/d2core/d2ui/widget.go
@@ -11,6 +11,8 @@ const (
 	RenderPrioritySkilltree
 	// RenderPrioritySkilltreeIcon is the priority for the skilltree icons
 	RenderPrioritySkilltreeIcon
+	// RenderPriorityHeroStatsPanel is the priority for the hero_stats_panel
+	RenderPriorityHeroStatsPanel
 	// RenderPriorityForeground is the last element drawn
 	RenderPriorityForeground
 )

--- a/d2core/d2ui/widget_group.go
+++ b/d2core/d2ui/widget_group.go
@@ -84,3 +84,16 @@ func (wg *WidgetGroup) SetVisible(visible bool) {
 		entry.SetVisible(visible)
 	}
 }
+
+// OnMouseMove handles mouse move events
+func (wg *WidgetGroup) OnMouseMove(x, y int) {
+	for _, entry := range wg.entries {
+		if entry.Contains(x, y) && entry.GetVisible() {
+			if !entry.isHovered() {
+				entry.hoverStart()
+			}
+		} else if entry.isHovered() {
+			entry.hoverEnd()
+		}
+	}
+}

--- a/d2core/d2ui/widget_group.go
+++ b/d2core/d2ui/widget_group.go
@@ -13,8 +13,7 @@ var _ Widget = &WidgetGroup{}
 // widgets at once.
 type WidgetGroup struct {
 	*BaseWidget
-	entries  []Widget
-	priority RenderPriority
+	entries []Widget
 }
 
 // NewWidgetGroup creates a new widget group

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -698,6 +698,8 @@ func (g *GameControls) Load() {
 // Advance advances the state of the GameControls
 func (g *GameControls) Advance(elapsed float64) error {
 	g.mapRenderer.Advance(elapsed)
+	g.heroStatsPanel.Advance(elapsed)
+
 	return nil
 }
 
@@ -770,7 +772,6 @@ func (g *GameControls) Render(target d2interface.Surface) error {
 }
 
 func (g *GameControls) renderPanels(target d2interface.Surface) error {
-	g.heroStatsPanel.Render(target)
 	g.inventory.Render(target)
 
 	return nil

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -57,7 +57,7 @@ const (
 	leftSkillX,
 	leftSkillY,
 	leftSkillWidth,
-	leftSkillHeight = 115, 550, 50, 50
+	leftSkillHeight = 117, 550, 50, 50
 
 	newStatsX,
 	newStatsY,
@@ -92,7 +92,7 @@ const (
 	rightSkillX,
 	rightSkillY,
 	rightSkillWidth,
-	rightSkillHeight = 634, 550, 50, 50
+	rightSkillHeight = 635, 550, 50, 50
 
 	hpGlobeX,
 	hpGlobeY,

--- a/d2game/d2player/globeWidget.go
+++ b/d2game/d2player/globeWidget.go
@@ -1,0 +1,136 @@
+package d2player
+
+import (
+	"image"
+	"log"
+
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2ui"
+)
+
+type globeType = int
+
+const (
+	typeHealthGlobe globeType = iota
+	typeManaGlobe
+)
+
+const (
+	globeHeight = 80
+	globeWidth  = 80
+
+	globeSpriteOffsetX = 28
+	globeSpriteOffsetY = -5
+
+	healthStatusOffsetX = 30
+	healthStatusOffsetY = -13
+
+	manaStatusOffsetX = 7
+	manaStatusOffsetY = -12
+
+	manaGlobeScreenOffsetX = 117
+)
+
+// static check that globeWidget implements Widget
+var _ d2ui.Widget = &globeWidget{}
+
+type globeFrame struct {
+	sprite  *d2ui.Sprite
+	offsetX int
+	offsetY int
+	idx     int
+}
+
+func (gf *globeFrame) setFrameIndex() {
+	if err := gf.sprite.SetCurrentFrame(gf.idx); err != nil {
+		log.Print(err)
+	}
+}
+
+func (gf *globeFrame) setPosition(x, y int) {
+	gf.sprite.SetPosition(x+gf.offsetX, y+gf.offsetY)
+}
+
+type globeWidget struct {
+	*d2ui.BaseWidget
+	value    *int
+	valueMax *int
+	globe    *globeFrame
+	overlap  *globeFrame
+}
+
+func newGlobeWidget(ui *d2ui.UIManager, x, y int, gtype globeType, value, valueMax *int) *globeWidget {
+	var globe, overlap *globeFrame
+
+	base := d2ui.NewBaseWidget(ui)
+	base.SetPosition(x, y)
+
+	if gtype == typeHealthGlobe {
+		globe = &globeFrame{
+			offsetX: healthStatusOffsetX,
+			offsetY: healthStatusOffsetY,
+			idx:     frameHealthStatus,
+		}
+		overlap = &globeFrame{
+			offsetX: globeSpriteOffsetX,
+			offsetY: globeSpriteOffsetY,
+			idx:     frameHealthStatus,
+		}
+	} else if gtype == typeManaGlobe {
+		globe = &globeFrame{
+			offsetX: manaStatusOffsetX,
+			offsetY: manaStatusOffsetY,
+			idx:     frameManaStatus,
+		}
+		overlap = &globeFrame{
+			offsetX: rightGlobeOffsetX,
+			offsetY: rightGlobeOffsetY,
+			idx:     frameRightGlobe,
+		}
+	}
+
+	return &globeWidget{
+		BaseWidget: base,
+		value:      value,
+		valueMax:   valueMax,
+		globe:      globe,
+		overlap:    overlap,
+	}
+}
+
+func (g *globeWidget) load() {
+	var err error
+
+	g.globe.sprite, err = g.GetManager().NewSprite(d2resource.HealthManaIndicator, d2resource.PaletteSky)
+	if err != nil {
+		log.Print(err)
+	}
+
+	g.globe.setFrameIndex()
+
+	g.overlap.sprite, err = g.GetManager().NewSprite(d2resource.GameGlobeOverlap, d2resource.PaletteSky)
+	if err != nil {
+		log.Print(err)
+	}
+
+	g.overlap.setFrameIndex()
+}
+
+// Render draws the widget to the screen
+func (g *globeWidget) Render(target d2interface.Surface) {
+	valuePercent := float64(*g.value) / float64(*g.valueMax)
+	barHeight := int(valuePercent * float64(globeHeight))
+
+	maskRect := image.Rect(0, globeHeight-barHeight, globeWidth, globeHeight)
+
+	g.globe.setPosition(g.GetPosition())
+	g.globe.sprite.RenderSection(target, maskRect)
+
+	g.overlap.setPosition(g.GetPosition())
+	g.overlap.sprite.Render(target)
+}
+
+func (g *globeWidget) Advance(elapsed float64) error {
+	return nil
+}

--- a/d2game/d2player/globeWidget.go
+++ b/d2game/d2player/globeWidget.go
@@ -52,6 +52,11 @@ func (gf *globeFrame) setPosition(x, y int) {
 	gf.sprite.SetPosition(x+gf.offsetX, y+gf.offsetY)
 }
 
+func (gf *globeFrame) getSize() (x, y int) {
+	w, h := gf.sprite.GetSize()
+	return w + gf.offsetX, h + gf.offsetY
+}
+
 type globeWidget struct {
 	*d2ui.BaseWidget
 	value    *int
@@ -129,6 +134,10 @@ func (g *globeWidget) Render(target d2interface.Surface) {
 
 	g.overlap.setPosition(g.GetPosition())
 	g.overlap.sprite.Render(target)
+}
+
+func (g *globeWidget) GetSize() (x, y int) {
+	return g.overlap.getSize()
 }
 
 func (g *globeWidget) Advance(elapsed float64) error {

--- a/d2game/d2player/hero_stats_panel.go
+++ b/d2game/d2player/hero_stats_panel.go
@@ -85,18 +85,15 @@ type StatsPanelLabels struct {
 
 // HeroStatsPanel represents the hero status panel
 type HeroStatsPanel struct {
-	asset       *d2asset.AssetManager
-	uiManager   *d2ui.UIManager
-	frame       *d2ui.UIFrame
-	panel       *d2ui.Sprite
-	heroState   *d2hero.HeroStatsState
-	heroName    string
-	heroClass   d2enum.Hero
-	labels      *StatsPanelLabels
-	closeButton *d2ui.Button
-	onCloseCb   func()
-	panelGroup  *d2ui.WidgetGroup
-	staticPanel *d2ui.CustomWidget
+	asset      *d2asset.AssetManager
+	uiManager  *d2ui.UIManager
+	panel      *d2ui.Sprite
+	heroState  *d2hero.HeroStatsState
+	heroName   string
+	heroClass  d2enum.Hero
+	labels     *StatsPanelLabels
+	onCloseCb  func()
+	panelGroup *d2ui.WidgetGroup
 
 	originX int
 	originY int
@@ -127,25 +124,25 @@ func (s *HeroStatsPanel) Load() {
 
 	s.panelGroup = s.uiManager.NewWidgetGroup(d2ui.RenderPriorityHeroStatsPanel)
 
-	s.frame = d2ui.NewUIFrame(s.asset, s.uiManager, d2ui.FrameLeft)
-	s.panelGroup.AddWidget(s.frame)
+	frame := d2ui.NewUIFrame(s.asset, s.uiManager, d2ui.FrameLeft)
+	s.panelGroup.AddWidget(frame)
 
 	s.panel, err = s.uiManager.NewSprite(d2resource.InventoryCharacterPanel, d2resource.PaletteSky)
 	if err != nil {
 		log.Print(err)
 	}
 
-	fw, fh := s.frame.GetFrameBounds()
-	fc := s.frame.GetFrameCount()
+	fw, fh := frame.GetFrameBounds()
+	fc := frame.GetFrameCount()
 	w, h := fw*fc, fh*fc
-	s.staticPanel = s.uiManager.NewCustomWidgetCached(s.renderStaticMenu, w, h)
-	s.panelGroup.AddWidget(s.staticPanel)
+	staticPanel := s.uiManager.NewCustomWidgetCached(s.renderStaticMenu, w, h)
+	s.panelGroup.AddWidget(staticPanel)
 
-	s.closeButton = s.uiManager.NewButton(d2ui.ButtonTypeSquareClose, "")
-	s.closeButton.SetVisible(false)
-	s.closeButton.SetPosition(heroStatsCloseButtonX, heroStatsCloseButtonY)
-	s.closeButton.OnActivated(func() { s.Close() })
-	s.panelGroup.AddWidget(s.closeButton)
+	closeButton := s.uiManager.NewButton(d2ui.ButtonTypeSquareClose, "")
+	closeButton.SetVisible(false)
+	closeButton.SetPosition(heroStatsCloseButtonX, heroStatsCloseButtonY)
+	closeButton.OnActivated(func() { s.Close() })
+	s.panelGroup.AddWidget(closeButton)
 
 	s.initStatValueLabels()
 	s.panelGroup.SetVisible(false)

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -114,6 +114,8 @@ type HUD struct {
 	manaGlobe          *globeWidget
 	widgetStamina      *d2ui.CustomWidget
 	widgetExperience   *d2ui.CustomWidget
+	widgetLeftSkill    *d2ui.CustomWidget
+	widgetRightSkill   *d2ui.CustomWidget
 }
 
 // NewHUD creates a HUD object
@@ -172,6 +174,24 @@ func (h *HUD) loadCustomWidgets() {
 	h.widgetStamina.SetPosition(staminaBarOffsetX, staminaBarOffsetY)
 
 	h.widgetExperience = h.uiManager.NewCustomWidget(h.renderExperienceBar, expBarWidth, expBarHeight)
+
+	// Left skill widget
+	leftRenderFunc := func(target d2interface.Surface) {
+		x, y := h.widgetLeftSkill.GetPosition()
+		h.renderLeftSkill(x, y, target)
+	}
+
+	h.widgetLeftSkill = h.uiManager.NewCustomWidget(leftRenderFunc, skillIconWidth, skillIconHeight)
+	h.widgetLeftSkill.SetPosition(leftSkillX, screenHeight)
+
+	// Right skill widget
+	rightRenderFunc := func(target d2interface.Surface) {
+		x, y := h.widgetRightSkill.GetPosition()
+		h.renderRightSkill(x, y, target)
+	}
+
+	h.widgetRightSkill = h.uiManager.NewCustomWidget(rightRenderFunc, skillIconWidth, skillIconHeight)
+	h.widgetRightSkill.SetPosition(rightSkillX, screenHeight)
 }
 
 func (h *HUD) loadSkillResources() {
@@ -320,19 +340,14 @@ func (h *HUD) renderGameControlPanelElements(target d2interface.Surface) error {
 	}
 
 	// Health globe
-	w, _ := h.mainPanel.GetCurrentFrameSize()
-
 	h.healthGlobe.Render(target)
 
 	// Left Skill
-	offsetX += w
-	if err := h.renderLeftSkill(offsetX, offsetY, target); err != nil {
-		return err
-	}
+	h.widgetLeftSkill.Render(target)
 
 	// New Stats Button
-	w, _ = h.leftSkillResource.SkillIcon.GetCurrentFrameSize()
-	offsetX += w
+	w, _ := h.mainPanel.GetCurrentFrameSize()
+	offsetX += w + skillIconWidth
 
 	if err := h.renderNewStatsButton(offsetX, offsetY, target); err != nil {
 		return err
@@ -374,16 +389,11 @@ func (h *HUD) renderGameControlPanelElements(target d2interface.Surface) error {
 	}
 
 	// Right skill
-	w, _ = h.mainPanel.GetCurrentFrameSize()
-	offsetX += w
-
-	if err := h.renderRightSkill(offsetX, offsetY, target); err != nil {
-		return err
-	}
+	h.widgetRightSkill.Render(target)
 
 	// Mana Globe
-	w, _ = h.rightSkillResource.SkillIcon.GetCurrentFrameSize()
-	offsetX += w
+	w, _ = h.mainPanel.GetCurrentFrameSize()
+	offsetX += w + skillIconWidth
 
 	if err := h.mainPanel.SetCurrentFrame(frameRightGlobeHolder); err != nil {
 		return err
@@ -408,7 +418,7 @@ func (h *HUD) renderPanel(x, y int, target d2interface.Surface) error {
 	return nil
 }
 
-func (h *HUD) renderLeftSkill(x, y int, target d2interface.Surface) error {
+func (h *HUD) renderLeftSkill(x, y int, target d2interface.Surface) {
 	newSkillResourcePath := h.getSkillResourceByClass(h.hero.LeftSkill.Charclass)
 	if newSkillResourcePath != h.leftSkillResource.SkillResourcePath {
 		h.leftSkillResource.SkillResourcePath = newSkillResourcePath
@@ -416,16 +426,15 @@ func (h *HUD) renderLeftSkill(x, y int, target d2interface.Surface) error {
 	}
 
 	if err := h.leftSkillResource.SkillIcon.SetCurrentFrame(h.hero.LeftSkill.IconCel); err != nil {
-		return err
+		log.Print(err)
+		return
 	}
 
 	h.leftSkillResource.SkillIcon.SetPosition(x, y)
 	h.leftSkillResource.SkillIcon.Render(target)
-
-	return nil
 }
 
-func (h *HUD) renderRightSkill(x, _ int, target d2interface.Surface) error {
+func (h *HUD) renderRightSkill(x, _ int, target d2interface.Surface) {
 	_, height := target.GetSize()
 
 	newSkillResourcePath := h.getSkillResourceByClass(h.hero.RightSkill.Charclass)
@@ -435,13 +444,12 @@ func (h *HUD) renderRightSkill(x, _ int, target d2interface.Surface) error {
 	}
 
 	if err := h.rightSkillResource.SkillIcon.SetCurrentFrame(h.hero.RightSkill.IconCel); err != nil {
-		return err
+		log.Print(err)
+		return
 	}
 
 	h.rightSkillResource.SkillIcon.SetPosition(x, height)
 	h.rightSkillResource.SkillIcon.Render(target)
-
-	return nil
 }
 
 func (h *HUD) renderNewStatsButton(x, y int, target d2interface.Surface) error {

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -30,6 +30,7 @@ const (
 
 const (
 	expBarWidth          = 120.0
+	expBarHeight         = 4
 	staminaBarWidth      = 102.0
 	staminaBarHeight     = 19.0
 	hoverLabelOuterPad   = 5
@@ -111,6 +112,8 @@ type HUD struct {
 	nameLabel          *d2ui.Label
 	healthGlobe        *globeWidget
 	manaGlobe          *globeWidget
+	widgetStamina      *d2ui.CustomWidget
+	widgetExperience   *d2ui.CustomWidget
 }
 
 // NewHUD creates a HUD object
@@ -159,8 +162,16 @@ func (h *HUD) Load() {
 	h.manaGlobe.load()
 
 	h.loadSkillResources()
+	h.loadCustomWidgets()
 	h.loadUIButtons()
 	h.loadTooltips()
+}
+
+func (h *HUD) loadCustomWidgets() {
+	h.widgetStamina = h.uiManager.NewCustomWidget(h.renderStaminaBar, staminaBarWidth, staminaBarHeight)
+	h.widgetStamina.SetPosition(staminaBarOffsetX, staminaBarOffsetY)
+
+	h.widgetExperience = h.uiManager.NewCustomWidget(h.renderExperienceBar, expBarWidth, expBarHeight)
 }
 
 func (h *HUD) loadSkillResources() {
@@ -339,14 +350,10 @@ func (h *HUD) renderGameControlPanelElements(target d2interface.Surface) error {
 	w, _ = h.mainPanel.GetCurrentFrameSize()
 	offsetX += w
 
-	if err := h.renderStaminaBar(target); err != nil {
-		return err
-	}
+	h.widgetStamina.Render(target)
 
 	// Experience status bar
-	if err := h.renderExperienceBar(target); err != nil {
-		return err
-	}
+	h.widgetExperience.Render(target)
 
 	// Mini Panel and button
 	if err := h.renderMiniPanel(target); err != nil {
@@ -459,7 +466,7 @@ func (h *HUD) renderStamina(x, y int, target d2interface.Surface) error {
 	return nil
 }
 
-func (h *HUD) renderStaminaBar(target d2interface.Surface) error {
+func (h *HUD) renderStaminaBar(target d2interface.Surface) {
 	target.PushTranslation(staminaBarOffsetX, staminaBarOffsetY)
 	defer target.Pop()
 
@@ -474,19 +481,15 @@ func (h *HUD) renderStaminaBar(target d2interface.Surface) error {
 	}
 
 	target.DrawRect(int(staminaPercent*staminaBarWidth), staminaBarHeight, staminaBarColor)
-
-	return nil
 }
 
-func (h *HUD) renderExperienceBar(target d2interface.Surface) error {
+func (h *HUD) renderExperienceBar(target d2interface.Surface) {
 	target.PushTranslation(experienceBarOffsetX, experienceBarOffsetY)
 	defer target.Pop()
 
 	expPercent := float64(h.hero.Stats.Experience) / float64(h.hero.Stats.NextLevelExp)
 
 	target.DrawRect(int(expPercent*expBarWidth), 2, d2util.Color(whiteAlpha100))
-
-	return nil
 }
 
 func (h *HUD) renderMiniPanel(target d2interface.Surface) error {

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -153,10 +153,40 @@ func NewHUD(
 
 // Load creates the ui elemets
 func (h *HUD) Load() {
-	var err error
+	h.loadSprites()
 
 	h.healthGlobe.load()
 	h.manaGlobe.load()
+
+	h.loadSkillResources()
+	h.loadUIButtons()
+	h.loadTooltips()
+}
+
+func (h *HUD) loadSkillResources() {
+	// https://github.com/OpenDiablo2/OpenDiablo2/issues/799
+	genericSkillsSprite, err := h.uiManager.NewSprite(d2resource.GenericSkills, d2resource.PaletteSky)
+	if err != nil {
+		log.Print(err)
+	}
+
+	attackIconID := 2
+
+	h.leftSkillResource = &SkillResource{
+		SkillIcon:         genericSkillsSprite,
+		IconNumber:        attackIconID,
+		SkillResourcePath: d2resource.GenericSkills,
+	}
+
+	h.rightSkillResource = &SkillResource{
+		SkillIcon:         genericSkillsSprite,
+		IconNumber:        attackIconID,
+		SkillResourcePath: d2resource.GenericSkills,
+	}
+}
+
+func (h *HUD) loadSprites() {
+	var err error
 
 	h.globeSprite, err = h.uiManager.NewSprite(d2resource.GameGlobeOverlap, d2resource.PaletteSky)
 	if err != nil {
@@ -182,29 +212,6 @@ func (h *HUD) Load() {
 	if err != nil {
 		log.Print(err)
 	}
-
-	// https://github.com/OpenDiablo2/OpenDiablo2/issues/799
-	genericSkillsSprite, err := h.uiManager.NewSprite(d2resource.GenericSkills, d2resource.PaletteSky)
-	if err != nil {
-		log.Print(err)
-	}
-
-	attackIconID := 2
-
-	h.leftSkillResource = &SkillResource{
-		SkillIcon:         genericSkillsSprite,
-		IconNumber:        attackIconID,
-		SkillResourcePath: d2resource.GenericSkills,
-	}
-
-	h.rightSkillResource = &SkillResource{
-		SkillIcon:         genericSkillsSprite,
-		IconNumber:        attackIconID,
-		SkillResourcePath: d2resource.GenericSkills,
-	}
-
-	h.loadUIButtons()
-	h.loadTooltips()
 }
 
 func (h *HUD) loadTooltips() {

--- a/d2game/d2player/skilltree.go
+++ b/d2game/d2player/skilltree.go
@@ -425,9 +425,6 @@ func (s *skillTree) renderTabCommon(target d2interface.Surface) {
 
 	skillPanel.SetPosition(x+w, y)
 	s.renderPanelSegment(target, frameCommonTabBottomRight)
-
-	// available skill points label
-	s.availSPLabel.Render(target)
 }
 
 func (s *skillTree) renderTab(target d2interface.Surface, tab int) {

--- a/d2game/d2player/skilltree.go
+++ b/d2game/d2player/skilltree.go
@@ -132,7 +132,7 @@ func (s *skillTree) load() {
 	s.panelGroup = s.uiManager.NewWidgetGroup(d2ui.RenderPrioritySkilltree)
 	s.iconGroup = s.uiManager.NewWidgetGroup(d2ui.RenderPrioritySkilltreeIcon)
 
-	s.panel = s.uiManager.NewCustomWidget(s.Render)
+	s.panel = s.uiManager.NewCustomWidget(s.Render, 400, 600)
 	s.panelGroup.AddWidget(s.panel)
 
 	s.frame = d2ui.NewUIFrame(s.asset, s.uiManager, d2ui.FrameRight)


### PR DESCRIPTION
Hi,

this is the next part in my endeavor of refactoring the ui panels. In this PR the highlights are:

* Reworked hero_stats_panel to use widgets only. So no more Render() calls for game_controls
* Refactored HUD:
  - health/mana globe are now its own class
  - static background images are now cached in a widget
  - exp/stamina bar are now a widget
  - left/rightskill icon are now a widget
* Widgets can now define a HoverStart() HoverEnd() callback, that is run when the mouse enter/leaves the widget

cheers,
 