### PR TITLE
updating git workflow to use golangci-lint version 1.32

### DIFF
--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -25,7 +25,7 @@ jobs:
                 continue-on-error: false
                 uses: golangci/golangci-lint-action@v1.2.1
                 with:
-                    version: v1.27
+                    version: v1.32
 
             -   name: Run tests
                 env:

--- a/.github/workflows/pushToMaster.yml
+++ b/.github/workflows/pushToMaster.yml
@@ -27,7 +27,7 @@ jobs:
                 continue-on-error: false
                 uses: golangci/golangci-lint-action@v1.2.1
                 with:
-                    version: v1.27
+                    version: v1.32
 
             -   name: Run tests
                 env:


### PR DESCRIPTION
was causing lint errors in our builds because it was using an older version.

we're updating from  v1.27