### PR TITLE
Ui minipanel refactor

### DIFF
--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -73,6 +73,7 @@ type ButtonLayout struct {
 	YSegments        int
 	BaseFrame        int
 	DisabledFrame    int
+	DisabledColor    uint32
 	TextOffset       int
 	FixedWidth       int
 	FixedHeight      int
@@ -157,6 +158,7 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 			XSegments:        buttonWideSegmentsX,
 			YSegments:        buttonWideSegmentsY,
 			DisabledFrame:    buttonWideDisabledFrame,
+			DisabledColor:    lightGreyAlpha75,
 			TextOffset:       buttonWideTextOffset,
 			ResourceName:     d2resource.WideButtonBlank,
 			PaletteName:      d2resource.PaletteUnits,
@@ -171,6 +173,7 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 			XSegments:        buttonShortSegmentsX,
 			YSegments:        buttonShortSegmentsY,
 			DisabledFrame:    buttonShortDisabledFrame,
+			DisabledColor:    lightGreyAlpha75,
 			TextOffset:       buttonShortTextOffset,
 			ResourceName:     d2resource.ShortButtonBlank,
 			PaletteName:      d2resource.PaletteUnits,
@@ -184,6 +187,7 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMedium: {
 			XSegments:        buttonMediumSegmentsX,
 			YSegments:        buttonMediumSegmentsY,
+			DisabledColor:    lightGreyAlpha75,
 			ResourceName:     d2resource.MediumButtonBlank,
 			PaletteName:      d2resource.PaletteUnits,
 			FontPath:         d2resource.FontExocet10,
@@ -197,6 +201,7 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 			XSegments:        buttonTallSegmentsX,
 			YSegments:        buttonTallSegmentsY,
 			TextOffset:       buttonTallTextOffset,
+			DisabledColor:    lightGreyAlpha75,
 			ResourceName:     d2resource.TallButtonBlank,
 			PaletteName:      d2resource.PaletteUnits,
 			FontPath:         d2resource.FontExocet10,
@@ -210,6 +215,7 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 			XSegments:        buttonOkCancelSegmentsX,
 			YSegments:        buttonOkCancelSegmentsY,
 			DisabledFrame:    buttonOkCancelDisabledFrame,
+			DisabledColor:    lightGreyAlpha75,
 			ResourceName:     d2resource.CancelButton,
 			PaletteName:      d2resource.PaletteUnits,
 			FontPath:         d2resource.FontRediculous,
@@ -223,6 +229,7 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 			XSegments:        buttonRunSegmentsX,
 			YSegments:        buttonRunSegmentsY,
 			DisabledFrame:    buttonRunDisabledFrame,
+			DisabledColor:    lightGreyAlpha75,
 			ResourceName:     d2resource.RunButton,
 			PaletteName:      d2resource.PaletteSky,
 			Toggleable:       true,
@@ -237,6 +244,7 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 			XSegments:        buttonBuySellSegmentsX,
 			YSegments:        buttonBuySellSegmentsY,
 			DisabledFrame:    buttonBuySellDisabledFrame,
+			DisabledColor:    lightGreyAlpha75,
 			ResourceName:     d2resource.BuySellButton,
 			PaletteName:      d2resource.PaletteUnits,
 			Toggleable:       true,
@@ -255,6 +263,7 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 			XSegments:        buttonSkillTreeTabXSegments,
 			YSegments:        buttonSkillTreeTabYSegments,
 			DisabledFrame:    buttonSkillTreeTabDisabledFrame,
+			DisabledColor:    lightGreyAlpha75,
 			BaseFrame:        buttonSkillTreeTabBaseFrame,
 			ResourceName:     d2resource.SkillsPanelAmazon,
 			PaletteName:      d2resource.PaletteSky,
@@ -270,6 +279,7 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
 			DisabledFrame:    buttonMinipanelDisabledFrame,
+			DisabledColor:    whiteAlpha100,
 			BaseFrame:        buttonMinipanelOpenCloseBaseFrame,
 			ResourceName:     d2resource.MenuButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -284,7 +294,6 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelCharacter: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
-			DisabledFrame:    buttonMinipanelDisabledFrame,
 			BaseFrame:        buttonMinipanelCharacterBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -299,7 +308,6 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelInventory: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
-			DisabledFrame:    buttonMinipanelDisabledFrame,
 			BaseFrame:        buttonMinipanelInventoryBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -314,7 +322,6 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelSkill: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
-			DisabledFrame:    buttonMinipanelDisabledFrame,
 			BaseFrame:        buttonMinipanelSkilltreeBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -329,7 +336,6 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelParty: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
-			DisabledFrame:    buttonMinipanelDisabledFrame,
 			BaseFrame:        buttonMinipanelPartyBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -344,7 +350,6 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelAutomap: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
-			DisabledFrame:    buttonMinipanelDisabledFrame,
 			BaseFrame:        buttonMinipanelAutomapBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -359,7 +364,6 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelMessage: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
-			DisabledFrame:    buttonMinipanelDisabledFrame,
 			BaseFrame:        buttonMinipanelMessageBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -374,7 +378,6 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelQuest: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
-			DisabledFrame:    buttonMinipanelDisabledFrame,
 			BaseFrame:        buttonMinipanelQuestBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -389,7 +392,6 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelMen: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
-			DisabledFrame:    buttonMinipanelDisabledFrame,
 			BaseFrame:        buttonMinipanelMenBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -624,7 +626,7 @@ func (v *Button) Render(target d2interface.Surface) {
 
 	switch {
 	case !v.enabled:
-		target.PushColor(d2util.Color(lightGreyAlpha75))
+		target.PushColor(d2util.Color(v.buttonLayout.DisabledColor))
 		defer target.Pop()
 		target.Render(v.disabledSurface)
 	case v.toggled && v.pressed:

--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -41,6 +41,7 @@ const (
 	ButtonTypeSquareClose        ButtonType = 20
 	ButtonTypeSkillTreeTab       ButtonType = 21
 	ButtonTypeMinipanelOpenClose ButtonType = 22
+	ButtonTypeMinipanelParty     ButtonType = 23
 
 	ButtonNoFixedWidth  int = -1
 	ButtonNoFixedHeight int = -1
@@ -132,6 +133,15 @@ const (
 	buttonMinipanelDisabledFrame      = 2
 	buttonMinipanelXSegments          = 1
 	buttonMinipanelYSegments          = 1
+
+	buttonMinipanelCharacterBaseFrame = 0
+	buttonMinipanelInventoryBaseFrame = 2
+	buttonMinipanelSkilltreeBaseFrame = 4
+	buttonMinipanelPartyBaseFrame     = 6
+	buttonMinipanelAutomapBaseFrame   = 8
+	buttonMinipanelMessageBaseFrame   = 10
+	buttonMinipanelQuestBaseFrame     = 12
+	buttonMinipanelMenBaseFrame       = 14
 
 	buttonRunSegmentsX     = 1
 	buttonRunSegmentsY     = 1
@@ -264,6 +274,126 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 			ResourceName:     d2resource.MenuButton,
 			PaletteName:      d2resource.PaletteSky,
 			Toggleable:       true,
+			FontPath:         d2resource.Font16,
+			AllowFrameChange: true,
+			HasImage:         true,
+			FixedWidth:       ButtonNoFixedWidth,
+			FixedHeight:      ButtonNoFixedHeight,
+			LabelColor:       whiteAlpha100,
+		},
+		ButtonTypeMinipanelCharacter: {
+			XSegments:        buttonMinipanelXSegments,
+			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelDisabledFrame,
+			BaseFrame:        buttonMinipanelCharacterBaseFrame,
+			ResourceName:     d2resource.MinipanelButton,
+			PaletteName:      d2resource.PaletteSky,
+			Toggleable:       false,
+			FontPath:         d2resource.Font16,
+			AllowFrameChange: true,
+			HasImage:         true,
+			FixedWidth:       ButtonNoFixedWidth,
+			FixedHeight:      ButtonNoFixedHeight,
+			LabelColor:       whiteAlpha100,
+		},
+		ButtonTypeMinipanelInventory: {
+			XSegments:        buttonMinipanelXSegments,
+			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelDisabledFrame,
+			BaseFrame:        buttonMinipanelInventoryBaseFrame,
+			ResourceName:     d2resource.MinipanelButton,
+			PaletteName:      d2resource.PaletteSky,
+			Toggleable:       false,
+			FontPath:         d2resource.Font16,
+			AllowFrameChange: true,
+			HasImage:         true,
+			FixedWidth:       ButtonNoFixedWidth,
+			FixedHeight:      ButtonNoFixedHeight,
+			LabelColor:       whiteAlpha100,
+		},
+		ButtonTypeMinipanelSkill: {
+			XSegments:        buttonMinipanelXSegments,
+			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelDisabledFrame,
+			BaseFrame:        buttonMinipanelSkilltreeBaseFrame,
+			ResourceName:     d2resource.MinipanelButton,
+			PaletteName:      d2resource.PaletteSky,
+			Toggleable:       false,
+			FontPath:         d2resource.Font16,
+			AllowFrameChange: true,
+			HasImage:         true,
+			FixedWidth:       ButtonNoFixedWidth,
+			FixedHeight:      ButtonNoFixedHeight,
+			LabelColor:       whiteAlpha100,
+		},
+		ButtonTypeMinipanelParty: {
+			XSegments:        buttonMinipanelXSegments,
+			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelDisabledFrame,
+			BaseFrame:        buttonMinipanelPartyBaseFrame,
+			ResourceName:     d2resource.MinipanelButton,
+			PaletteName:      d2resource.PaletteSky,
+			Toggleable:       false,
+			FontPath:         d2resource.Font16,
+			AllowFrameChange: true,
+			HasImage:         true,
+			FixedWidth:       ButtonNoFixedWidth,
+			FixedHeight:      ButtonNoFixedHeight,
+			LabelColor:       whiteAlpha100,
+		},
+		ButtonTypeMinipanelAutomap: {
+			XSegments:        buttonMinipanelXSegments,
+			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelDisabledFrame,
+			BaseFrame:        buttonMinipanelAutomapBaseFrame,
+			ResourceName:     d2resource.MinipanelButton,
+			PaletteName:      d2resource.PaletteSky,
+			Toggleable:       false,
+			FontPath:         d2resource.Font16,
+			AllowFrameChange: true,
+			HasImage:         true,
+			FixedWidth:       ButtonNoFixedWidth,
+			FixedHeight:      ButtonNoFixedHeight,
+			LabelColor:       whiteAlpha100,
+		},
+		ButtonTypeMinipanelMessage: {
+			XSegments:        buttonMinipanelXSegments,
+			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelDisabledFrame,
+			BaseFrame:        buttonMinipanelMessageBaseFrame,
+			ResourceName:     d2resource.MinipanelButton,
+			PaletteName:      d2resource.PaletteSky,
+			Toggleable:       false,
+			FontPath:         d2resource.Font16,
+			AllowFrameChange: true,
+			HasImage:         true,
+			FixedWidth:       ButtonNoFixedWidth,
+			FixedHeight:      ButtonNoFixedHeight,
+			LabelColor:       whiteAlpha100,
+		},
+		ButtonTypeMinipanelQuest: {
+			XSegments:        buttonMinipanelXSegments,
+			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelDisabledFrame,
+			BaseFrame:        buttonMinipanelQuestBaseFrame,
+			ResourceName:     d2resource.MinipanelButton,
+			PaletteName:      d2resource.PaletteSky,
+			Toggleable:       false,
+			FontPath:         d2resource.Font16,
+			AllowFrameChange: true,
+			HasImage:         true,
+			FixedWidth:       ButtonNoFixedWidth,
+			FixedHeight:      ButtonNoFixedHeight,
+			LabelColor:       whiteAlpha100,
+		},
+		ButtonTypeMinipanelMen: {
+			XSegments:        buttonMinipanelXSegments,
+			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelDisabledFrame,
+			BaseFrame:        buttonMinipanelMenBaseFrame,
+			ResourceName:     d2resource.MinipanelButton,
+			PaletteName:      d2resource.PaletteSky,
+			Toggleable:       false,
 			FontPath:         d2resource.Font16,
 			AllowFrameChange: true,
 			HasImage:         true,

--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -40,6 +40,7 @@ const (
 	ButtonTypeMinipanelMen       ButtonType = 19
 	ButtonTypeSquareClose        ButtonType = 20
 	ButtonTypeSkillTreeTab       ButtonType = 21
+	ButtonTypeMinipanelOpenClose ButtonType = 22
 
 	ButtonNoFixedWidth  int = -1
 	ButtonNoFixedHeight int = -1
@@ -112,6 +113,11 @@ const (
 	buttonSkillTreeTabBaseFrame     = 7
 	buttonSkillTreeTabFixedWidth    = 93
 	buttonSkillTreeTabFixedHeight   = 107
+
+	buttonMinipanelOpenCloseBaseFrame = 0
+	buttonMinipanelDisabledFrame      = 2
+	buttonMinipanelXSegments          = 1
+	buttonMinipanelYSegments          = 1
 
 	buttonRunSegmentsX     = 1
 	buttonRunSegmentsY     = 1
@@ -231,6 +237,21 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 			HasImage:         false,
 			FixedWidth:       buttonSkillTreeTabFixedWidth,
 			FixedHeight:      buttonSkillTreeTabFixedHeight,
+			LabelColor:       whiteAlpha100,
+		},
+		ButtonTypeMinipanelOpenClose: {
+			XSegments:        buttonMinipanelXSegments,
+			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelDisabledFrame,
+			BaseFrame:        buttonMinipanelOpenCloseBaseFrame,
+			ResourceName:     d2resource.MenuButton,
+			PaletteName:      d2resource.PaletteSky,
+			Toggleable:       true,
+			FontPath:         d2resource.Font16,
+			AllowFrameChange: true,
+			HasImage:         true,
+			FixedWidth:       ButtonNoFixedWidth,
+			FixedHeight:      ButtonNoFixedHeight,
 			LabelColor:       whiteAlpha100,
 		},
 	}

--- a/d2core/d2ui/frame.go
+++ b/d2core/d2ui/frame.go
@@ -32,7 +32,7 @@ type UIFrame struct {
 const (
 	leftFrameTopLeft = iota
 	leftFrameTopRight
-	leftFrameMiddleRight
+	leftFrameMiddleLeft
 	leftFrameBottomLeft
 	leftFrameBottomRight
 	rightFrameTopLeft
@@ -80,6 +80,51 @@ func (u *UIFrame) Load() {
 	}
 
 	u.frame = sprite
+	u.calculateSize()
+}
+
+func (u *UIFrame) calculateSize() {
+	var framesWidth, framesHeight []int
+
+	if u.frameOrientation == FrameLeft {
+		framesWidth = []int{
+			leftFrameTopLeft,
+			leftFrameTopRight,
+		}
+		framesHeight = []int{
+			leftFrameTopLeft,
+			leftFrameMiddleLeft,
+			leftFrameBottomLeft,
+		}
+	} else if u.frameOrientation == FrameRight {
+		framesWidth = []int{
+			rightFrameTopLeft,
+			rightFrameTopRight,
+		}
+		framesHeight = []int{
+			rightFrameTopRight,
+			rightFrameMiddleRight,
+			rightFrameBottomRight,
+		}
+	}
+
+	for i := range framesWidth {
+		w, _, err := u.frame.GetFrameSize(framesWidth[i])
+		if err != nil {
+			log.Print(err)
+		}
+
+		u.width += w
+	}
+
+	for i := range framesHeight {
+		_, h, err := u.frame.GetFrameSize(framesHeight[i])
+		if err != nil {
+			log.Print(err)
+		}
+
+		u.height += h
+	}
 }
 
 // Render the frame to the target surface
@@ -101,7 +146,7 @@ func (u *UIFrame) renderLeft(target d2interface.Surface) error {
 	framePieces := []int{
 		leftFrameTopLeft,
 		leftFrameTopRight,
-		leftFrameMiddleRight,
+		leftFrameMiddleLeft,
 		leftFrameBottomLeft,
 		leftFrameBottomRight,
 	}
@@ -129,7 +174,7 @@ func (u *UIFrame) renderLeft(target d2interface.Surface) error {
 		case leftFrameTopRight:
 			c.x, c.y = currentX, startY+height
 			currentX = startX
-		case leftFrameMiddleRight:
+		case leftFrameMiddleLeft:
 			c.x, c.y = currentX, currentY+height
 			currentY += height
 		case leftFrameBottomLeft:

--- a/d2core/d2ui/ui_manager.go
+++ b/d2core/d2ui/ui_manager.go
@@ -105,6 +105,12 @@ func (ui *UIManager) OnMouseMove(event d2interface.MouseMoveEvent) bool {
 		}
 	}
 
+	for _, w := range ui.widgets {
+		if w.GetVisible() {
+			w.OnMouseMove(event.X(), event.Y())
+		}
+	}
+
 	return false
 }
 
@@ -134,15 +140,15 @@ func (ui *UIManager) OnMouseButtonDown(event d2interface.MouseEvent) bool {
 
 // Render renders all of the UI elements
 func (ui *UIManager) Render(target d2interface.Surface) {
-	for _, widget := range ui.widgets {
-		if widget.GetVisible() {
-			widget.Render(target)
-		}
-	}
-
 	for _, widgetGroup := range ui.widgetsGroups {
 		if widgetGroup.GetVisible() {
 			widgetGroup.Render(target)
+		}
+	}
+
+	for _, widget := range ui.widgets {
+		if widget.GetVisible() {
+			widget.Render(target)
 		}
 	}
 }

--- a/d2core/d2ui/widget.go
+++ b/d2core/d2ui/widget.go
@@ -22,6 +22,7 @@ type Widget interface {
 	Drawable
 	bindManager(ui *UIManager)
 	GetManager() (ui *UIManager)
+	OnMouseMove(x int, y int)
 	OnHoverStart(callback func())
 	OnHoverEnd(callback func())
 	isHovered() bool
@@ -155,4 +156,15 @@ func (b *BaseWidget) Contains(x, y int) bool {
 // GetManager returns the uiManager
 func (b *BaseWidget) GetManager() (ui *UIManager) {
 	return b.manager
+}
+
+// OnMouseMove is called when the mouse is moved
+func (b *BaseWidget) OnMouseMove(x, y int) {
+	if b.Contains(x, y) {
+		if !b.isHovered() {
+			b.hoverStart()
+		}
+	} else if b.isHovered() {
+		b.hoverEnd()
+	}
 }

--- a/d2core/d2ui/widget.go
+++ b/d2core/d2ui/widget.go
@@ -11,6 +11,8 @@ const (
 	RenderPrioritySkilltree
 	// RenderPrioritySkilltreeIcon is the priority for the skilltree icons
 	RenderPrioritySkilltreeIcon
+	// RenderPriorityMinipanel is the priority for the minipanel icons
+	RenderPriorityMinipanel
 	// RenderPriorityHeroStatsPanel is the priority for the hero_stats_panel
 	RenderPriorityHeroStatsPanel
 	// RenderPriorityForeground is the last element drawn

--- a/d2core/d2ui/widget_group.go
+++ b/d2core/d2ui/widget_group.go
@@ -44,8 +44,8 @@ func (wg *WidgetGroup) adjustSize(w Widget) {
 	x, y := w.GetPosition()
 	width, height := w.GetSize()
 
-	if x+width > wg.width {
-		wg.width = x + width
+	if x+width > wg.x + wg.width {
+		wg.width += (x + width) - (wg.x + wg.width)
 	}
 
 	if wg.x > x {
@@ -53,8 +53,8 @@ func (wg *WidgetGroup) adjustSize(w Widget) {
 		wg.x = x
 	}
 
-	if y+height > wg.height {
-		wg.height = x + height
+	if y+height > wg.y + wg.height {
+		wg.height += (y + height) - (wg.y + wg.height)
 	}
 
 	if wg.y > y {

--- a/d2core/d2ui/widget_group.go
+++ b/d2core/d2ui/widget_group.go
@@ -1,10 +1,13 @@
 package d2ui
 
 import (
+	"image/color"
 	"sort"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 )
+
+const widgetGroupDebug = false // turns on debug rendering stuff for groups
 
 // static check that WidgetGroup implements widget
 var _ Widget = &WidgetGroup{}
@@ -76,6 +79,23 @@ func (wg *WidgetGroup) Render(target d2interface.Surface) {
 			entry.Render(target)
 		}
 	}
+
+	if widgetGroupDebug && wg.GetVisible() {
+		wg.renderDebug(target)
+	}
+}
+
+
+func (wg *WidgetGroup) renderDebug(target d2interface.Surface) {
+	target.PushTranslation(wg.GetPosition())
+	defer target.Pop()
+	target.DrawLine(wg.width, 0, color.White)
+	target.DrawLine(0, wg.height, color.White)
+
+	target.PushTranslation(wg.width, wg.height)
+	target.DrawLine(-wg.width, 0, color.White)
+	target.DrawLine(0, -wg.height, color.White)
+	target.Pop()
 }
 
 // SetVisible sets the visibility of all widgets in the group

--- a/d2core/d2ui/widget_group.go
+++ b/d2core/d2ui/widget_group.go
@@ -106,6 +106,15 @@ func (wg *WidgetGroup) SetVisible(visible bool) {
 	}
 }
 
+// OffsetPosition moves all widgets by x and y
+func (wg *WidgetGroup) OffsetPosition(x, y int) {
+	wg.BaseWidget.OffsetPosition(x, y)
+
+	for _, entry := range wg.entries {
+		entry.OffsetPosition(x, y)
+	}
+}
+
 // OnMouseMove handles mouse move events
 func (wg *WidgetGroup) OnMouseMove(x, y int) {
 	for _, entry := range wg.entries {

--- a/d2core/d2ui/widget_group.go
+++ b/d2core/d2ui/widget_group.go
@@ -47,7 +47,7 @@ func (wg *WidgetGroup) adjustSize(w Widget) {
 	x, y := w.GetPosition()
 	width, height := w.GetSize()
 
-	if x+width > wg.x + wg.width {
+	if x+width > wg.x+wg.width {
 		wg.width += (x + width) - (wg.x + wg.width)
 	}
 
@@ -56,7 +56,7 @@ func (wg *WidgetGroup) adjustSize(w Widget) {
 		wg.x = x
 	}
 
-	if y+height > wg.y + wg.height {
+	if y+height > wg.y+wg.height {
 		wg.height += (y + height) - (wg.y + wg.height)
 	}
 
@@ -85,7 +85,6 @@ func (wg *WidgetGroup) Render(target d2interface.Surface) {
 	}
 }
 
-
 func (wg *WidgetGroup) renderDebug(target d2interface.Surface) {
 	target.PushTranslation(wg.GetPosition())
 	defer target.Pop()
@@ -101,6 +100,7 @@ func (wg *WidgetGroup) renderDebug(target d2interface.Surface) {
 // SetVisible sets the visibility of all widgets in the group
 func (wg *WidgetGroup) SetVisible(visible bool) {
 	wg.BaseWidget.SetVisible(visible)
+
 	for _, entry := range wg.entries {
 		entry.SetVisible(visible)
 	}

--- a/d2core/d2ui/widget_group.go
+++ b/d2core/d2ui/widget_group.go
@@ -100,6 +100,7 @@ func (wg *WidgetGroup) renderDebug(target d2interface.Surface) {
 
 // SetVisible sets the visibility of all widgets in the group
 func (wg *WidgetGroup) SetVisible(visible bool) {
+	wg.BaseWidget.SetVisible(visible)
 	for _, entry := range wg.entries {
 		entry.SetVisible(visible)
 	}

--- a/d2game/d2player/escape_menu.go
+++ b/d2game/d2player/escape_menu.go
@@ -80,6 +80,8 @@ type EscapeMenu struct {
 	assetManager   *d2asset.AssetManager
 	keyMap         *KeyMap
 	keyBindingMenu *KeyBindingMenu
+
+	onCloseCb      func()
 }
 
 type layout struct {
@@ -410,10 +412,15 @@ func (m *EscapeMenu) OnEscKey() {
 	m.close()
 }
 
+func (m *EscapeMenu) SetOnCloseCb(cb func()) {
+	m.onCloseCb = cb
+}
+
 func (m *EscapeMenu) close() {
 	m.isOpen = false
 
 	m.guiManager.SetLayout(nil)
+	m.onCloseCb()
 }
 
 func (m *EscapeMenu) open() {

--- a/d2game/d2player/escape_menu.go
+++ b/d2game/d2player/escape_menu.go
@@ -81,7 +81,7 @@ type EscapeMenu struct {
 	keyMap         *KeyMap
 	keyBindingMenu *KeyBindingMenu
 
-	onCloseCb      func()
+	onCloseCb func()
 }
 
 type layout struct {
@@ -412,6 +412,7 @@ func (m *EscapeMenu) OnEscKey() {
 	m.close()
 }
 
+// SetOnCloseCb sets the callback that is run when close() is called
 func (m *EscapeMenu) SetOnCloseCb(cb func()) {
 	m.onCloseCb = cb
 }

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -342,10 +342,9 @@ func NewGameControls(
 		isSinglePlayer:         isSinglePlayer,
 	}
 
-	closeCb := func() { gc.updateLayout() }
-	gc.heroStatsPanel.SetOnCloseCb(closeCb)
-	gc.inventory.SetOnCloseCb(closeCb)
-	gc.skilltree.SetOnCloseCb(closeCb)
+	gc.heroStatsPanel.SetOnCloseCb(gc.onCloseHeroStatsPanel)
+	gc.inventory.SetOnCloseCb(gc.onCloseInventory)
+	gc.skilltree.SetOnCloseCb(gc.onCloseSkilltree)
 
 	gc.escapeMenu.SetOnCloseCb(gc.hud.restoreMinipanelFromTempClose)
 
@@ -640,6 +639,11 @@ func (g *GameControls) toggleHeroStatsPanel() {
 	g.updateLayout()
 }
 
+func (g *GameControls) onCloseHeroStatsPanel() {
+	g.hud.miniPanel.SetMovedRight(g.heroStatsPanel.IsOpen())
+	g.updateLayout()
+}
+
 func (g *GameControls) toggleInventoryPanel() {
 	g.skilltree.Close()
 	g.inventory.Toggle()
@@ -647,9 +651,19 @@ func (g *GameControls) toggleInventoryPanel() {
 	g.updateLayout()
 }
 
+func (g *GameControls) onCloseInventory() {
+	g.hud.miniPanel.SetMovedLeft(g.inventory.IsOpen())
+	g.updateLayout()
+}
+
 func (g *GameControls) toggleSkilltreePanel() {
 	g.inventory.Close()
 	g.skilltree.Toggle()
+	g.hud.miniPanel.SetMovedLeft(g.skilltree.IsOpen())
+	g.updateLayout()
+}
+
+func (g *GameControls) onCloseSkilltree() {
 	g.hud.miniPanel.SetMovedLeft(g.skilltree.IsOpen())
 	g.updateLayout()
 }

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -79,11 +79,6 @@ const (
 	staminaWidth,
 	staminaHeight = 273, 573, 105, 20
 
-	miniPnlX,
-	miniPnlY,
-	miniPnlWidth,
-	miniPnlHeight = 393, 563, 12, 23
-
 	newSkillsX,
 	newSkillsY,
 	newSkillsWidth,
@@ -268,12 +263,6 @@ func NewGameControls(
 			Top:    staminaY,
 			Width:  staminaWidth,
 			Height: staminaHeight,
-		}},
-		{miniPnl, d2geom.Rectangle{
-			Left:   miniPnlX,
-			Top:    miniPnlY,
-			Width:  miniPnlWidth,
-			Height: miniPnlHeight,
 		}},
 		{newSkills, d2geom.Rectangle{
 			Left:   newSkillsX,
@@ -877,12 +866,6 @@ func (g *GameControls) onClickActionable(item actionableType) {
 
 		stamina: func() {
 			log.Println("Stamina Action Pressed")
-		},
-
-		miniPnl: func() {
-			log.Println("Mini Panel Action Pressed")
-
-			g.hud.miniPanel.Toggle()
 		},
 
 		newSkills: func() {

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -90,41 +90,6 @@ const (
 	manaGlobeY,
 	manaGlobeWidth,
 	manaGlobeHeight = 695, 525, 80, 60
-
-	miniPanelCharacterX,
-	miniPanelCharacterY,
-	miniPanelCharacterWidth,
-	miniPanelCharacterHeight = 324, 528, 22, 26
-
-	miniPanelInventoryX,
-	miniPanelInventoryY,
-	miniPanelInventoryWidth,
-	miniPanelInventoryHeight = 346, 528, 22, 26
-
-	miniPanelSkillTreeX,
-	miniPanelSkillTreeY,
-	miniPanelSkillTreeWidth,
-	miniPanelSkillTreeHeight = 368, 528, 22, 26
-
-	miniPanelAutomapX,
-	miniPanelAutomapY,
-	miniPanelAutomapWidth,
-	miniPanelAutomapHeight = 390, 528, 22, 26
-
-	miniPanelMessageLogX,
-	miniPanelMessageLogY,
-	miniPanelMessageLogWidth,
-	miniPanelMessageLogHeight = 412, 528, 22, 26
-
-	miniPanelQuestLogX,
-	miniPanelQuestLogY,
-	miniPanelQuestLogWidth,
-	miniPanelQuestLogHeight = 434, 528, 22, 26
-
-	miniPanelGameMenuX,
-	miniPanelGameMenuY,
-	miniPanelGameMenuWidth,
-	miniPanelGameMenuHeight = 456, 528, 22, 26
 )
 
 const (
@@ -286,7 +251,6 @@ func NewGameControls(
 	heroStatsPanel := NewHeroStatsPanel(asset, ui, hero.Name(), hero.Class, hero.Stats)
 	inventory := NewInventory(asset, ui, inventoryRecord)
 	skilltree := newSkillTree(hero.Skills, hero.Class, asset, ui)
-
 
 	miniPanel := newMiniPanel(asset, ui, isSinglePlayer)
 
@@ -677,7 +641,6 @@ func (g *GameControls) openEscMenu() {
 	g.updateLayout()
 }
 
-
 // Load the resources required for the GameControls
 func (g *GameControls) Load() {
 	g.hud.Load()
@@ -686,12 +649,12 @@ func (g *GameControls) Load() {
 	g.heroStatsPanel.Load()
 	g.HelpOverlay.Load()
 
-	miniPanelActions := &miniPanelActions {
-			characterToggle: g.toggleHeroStatsPanel,
-			inventoryToggle: g.toggleInventoryPanel,
-			skilltreeToggle: g.toggleSkilltreePanel,
-			menuToggle:      g.openEscMenu,
-		}
+	miniPanelActions := &miniPanelActions{
+		characterToggle: g.toggleHeroStatsPanel,
+		inventoryToggle: g.toggleInventoryPanel,
+		skilltreeToggle: g.toggleSkilltreePanel,
+		menuToggle:      g.openEscMenu,
+	}
 	g.hud.miniPanel.load(miniPanelActions)
 }
 
@@ -824,15 +787,15 @@ func (g *GameControls) ToggleManaStats() {
 // Handles what to do when an actionable is hovered
 func (g *GameControls) onHoverActionable(item actionableType) {
 	hoverMap := map[actionableType]func(){
-		leftSkill:           func() {},
-		newStats:            func() {},
-		xp:                  func() {},
-		walkRun:             func() {},
-		stamina:             func() {},
-		newSkills:           func() {},
-		rightSkill:          func() {},
-		hpGlobe:             func() {},
-		manaGlobe:           func() {},
+		leftSkill:  func() {},
+		newStats:   func() {},
+		xp:         func() {},
+		walkRun:    func() {},
+		stamina:    func() {},
+		newSkills:  func() {},
+		rightSkill: func() {},
+		hpGlobe:    func() {},
+		manaGlobe:  func() {},
 	}
 
 	onHover, found := hoverMap[item]

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -636,18 +636,21 @@ func (g *GameControls) OnMouseButtonDown(event d2interface.MouseEvent) bool {
 
 func (g *GameControls) toggleHeroStatsPanel() {
 	g.heroStatsPanel.Toggle()
+	g.hud.miniPanel.SetMovedRight(g.heroStatsPanel.IsOpen())
 	g.updateLayout()
 }
 
 func (g *GameControls) toggleInventoryPanel() {
 	g.skilltree.Close()
 	g.inventory.Toggle()
+	g.hud.miniPanel.SetMovedLeft(g.inventory.IsOpen())
 	g.updateLayout()
 }
 
 func (g *GameControls) toggleSkilltreePanel() {
 	g.inventory.Close()
 	g.skilltree.Toggle()
+	g.hud.miniPanel.SetMovedLeft(g.skilltree.IsOpen())
 	g.updateLayout()
 }
 

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -347,6 +347,8 @@ func NewGameControls(
 	gc.inventory.SetOnCloseCb(closeCb)
 	gc.skilltree.SetOnCloseCb(closeCb)
 
+	gc.escapeMenu.SetOnCloseCb(gc.hud.restoreMinipanelFromTempClose)
+
 	err = gc.bindTerminalCommands(term)
 	if err != nil {
 		return nil, err
@@ -412,14 +414,11 @@ func (g *GameControls) OnKeyDown(event d2interface.KeyEvent) bool {
 		g.HelpOverlay.Close()
 		g.updateLayout()
 	case d2enum.ToggleInventoryPanel:
-		g.inventory.Toggle()
-		g.updateLayout()
+		g.toggleInventoryPanel()
 	case d2enum.ToggleSkillTreePanel:
-		g.skilltree.Toggle()
-		g.updateLayout()
+		g.toggleInventoryPanel()
 	case d2enum.ToggleCharacterPanel:
-		g.heroStatsPanel.Toggle()
-		g.updateLayout()
+		g.toggleHeroStatsPanel()
 	case d2enum.ToggleRunWalk:
 		g.hud.onToggleRunButton(false)
 	case d2enum.HoldRun:
@@ -492,7 +491,7 @@ func (g *GameControls) onEscKey() {
 		if g.escapeMenu.IsOpen() {
 			g.escapeMenu.OnEscKey()
 		} else {
-			g.escapeMenu.open()
+			g.openEscMenu()
 		}
 	}
 }
@@ -635,6 +634,33 @@ func (g *GameControls) OnMouseButtonDown(event d2interface.MouseEvent) bool {
 	return false
 }
 
+func (g *GameControls) toggleHeroStatsPanel() {
+	g.heroStatsPanel.Toggle()
+	g.updateLayout()
+}
+
+func (g *GameControls) toggleInventoryPanel() {
+	g.skilltree.Close()
+	g.inventory.Toggle()
+	g.updateLayout()
+}
+
+func (g *GameControls) toggleSkilltreePanel() {
+	g.inventory.Close()
+	g.skilltree.Toggle()
+	g.updateLayout()
+}
+
+func (g *GameControls) openEscMenu() {
+	g.inventory.Close()
+	g.skilltree.Close()
+	g.heroStatsPanel.Close()
+	g.hud.closeMinipanelTemporary()
+	g.escapeMenu.open()
+	g.updateLayout()
+}
+
+
 // Load the resources required for the GameControls
 func (g *GameControls) Load() {
 	g.hud.Load()
@@ -644,10 +670,10 @@ func (g *GameControls) Load() {
 	g.HelpOverlay.Load()
 
 	miniPanelActions := &miniPanelActions {
-		characterToggle: g.heroStatsPanel.Toggle,
-			inventoryToggle: g.inventory.Toggle,
-			skilltreeToggle: g.skilltree.Toggle,
-			menuToggle:      g.escapeMenu.open,
+			characterToggle: g.toggleHeroStatsPanel,
+			inventoryToggle: g.toggleInventoryPanel,
+			skilltreeToggle: g.toggleSkilltreePanel,
+			menuToggle:      g.openEscMenu,
 		}
 	g.hud.miniPanel.load(miniPanelActions)
 }

--- a/d2game/d2player/hero_stats_panel.go
+++ b/d2game/d2player/hero_stats_panel.go
@@ -131,9 +131,7 @@ func (s *HeroStatsPanel) Load() {
 		log.Print(err)
 	}
 
-	fw, fh := frame.GetFrameBounds()
-	fc := frame.GetFrameCount()
-	w, h := fw*fc, fh*fc
+	w, h := frame.GetSize()
 	staticPanel := s.uiManager.NewCustomWidgetCached(s.renderStaticMenu, w, h)
 	s.panelGroup.AddWidget(staticPanel)
 

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -666,7 +666,6 @@ func (h *HUD) Render(target d2interface.Surface) error {
 	h.manaGlobe.Render(target)
 	h.widgetStamina.Render(target)
 	h.widgetExperience.Render(target)
-	h.miniPanel.Render(target)
 
 	if err := h.help.Render(target); err != nil {
 		return err

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -97,6 +97,7 @@ type HUD struct {
 	runButton          *d2ui.Button
 	zoneChangeText     *d2ui.Label
 	miniPanel          *miniPanel
+	isMiniPanelOpen    bool
 	isZoneTextShown    bool
 	hpStatsIsVisible   bool
 	manaStatsIsVisible bool
@@ -720,3 +721,21 @@ func (h *HUD) OnMouseMove(event d2interface.MouseMoveEvent) bool {
 
 	return false
 }
+
+func (h *HUD) closeMinipanelTemporary() {
+	h.isMiniPanelOpen = h.miniPanel.IsOpen()
+	if h.isMiniPanelOpen {
+		h.menuButton.SetEnabled(false)
+		h.menuButton.Toggle()
+		h.miniPanel.Close()
+	}
+}
+
+func (h *HUD) restoreMinipanelFromTempClose() {
+	if h.isMiniPanelOpen {
+		h.menuButton.SetEnabled(true)
+		h.menuButton.Toggle()
+		h.miniPanel.Open()
+	}
+}
+

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -738,4 +738,3 @@ func (h *HUD) restoreMinipanelFromTempClose() {
 		h.miniPanel.Open()
 	}
 }
-

--- a/d2game/d2player/mini_panel.go
+++ b/d2game/d2player/mini_panel.go
@@ -3,8 +3,6 @@ package d2player
 import (
 	"log"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2geom"
-	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2ui"
@@ -19,58 +17,125 @@ const (
 
 const (
 	containerOffsetX = -75
-	containerOffsetY = -48
+	containerOffsetY = -49
 
 	buttonOffsetX = -72
-	buttonOffsetY = -51
+	buttonOffsetY = -52
 )
 
+type miniPanelActions struct {
+	characterToggle func()
+	inventoryToggle func()
+	skilltreeToggle func()
+	partyToggle     func()
+	automapToggle   func()
+	messageToggle   func()
+	questToggle     func()
+	menuToggle      func()
+}
+
 type miniPanel struct {
+	ui             *d2ui.UIManager
 	asset          *d2asset.AssetManager
 	container      *d2ui.Sprite
-	button         *d2ui.Sprite
+	sprite         *d2ui.Sprite
 	isOpen         bool
 	isSinglePlayer bool
-	rectangle      d2geom.Rectangle
+	panelGroup     *d2ui.WidgetGroup
 }
 
 func newMiniPanel(asset *d2asset.AssetManager, uiManager *d2ui.UIManager, isSinglePlayer bool) *miniPanel {
-	miniPanelContainerPath := d2resource.Minipanel
-	if isSinglePlayer {
-		miniPanelContainerPath = d2resource.MinipanelSmall
-	}
-
-	containerSprite, err := uiManager.NewSprite(miniPanelContainerPath, d2resource.PaletteSky)
-	if err != nil {
-		log.Print(err)
-		return nil
-	}
-
-	buttonSprite, err := uiManager.NewSprite(d2resource.MinipanelButton, d2resource.PaletteSky)
-	if err != nil {
-		log.Print(err)
-		return nil
-	}
-
-	rectangle := d2geom.Rectangle{
-		Left:   miniPanelX,
-		Top:    miniPanelY,
-		Width:  miniPanelWidth,
-		Height: miniPanelHeight,
-	}
-
-	if !isSinglePlayer {
-		rectangle.Width = 182
-	}
-
 	return &miniPanel{
+		ui: uiManager,
 		asset:          asset,
-		container:      containerSprite,
-		button:         buttonSprite,
 		isOpen:         false,
 		isSinglePlayer: isSinglePlayer,
-		rectangle:      rectangle,
 	}
+}
+
+func (m *miniPanel) load(actions *miniPanelActions) {
+	var err error
+
+	m.sprite, err = m.ui.NewSprite(d2resource.MinipanelButton, d2resource.PaletteSky)
+	if err != nil {
+		log.Print(err)
+		return
+	}
+
+	m.createWidgets(actions)
+}
+
+func (m *miniPanel) createWidgets(actions *miniPanelActions) {
+	var err error
+
+	m.panelGroup = m.ui.NewWidgetGroup(d2ui.RenderPriorityMinipanel)
+	m.panelGroup.SetPosition(miniPanelX, miniPanelY)
+
+	miniPanelContainerPath := d2resource.Minipanel
+	if m.isSinglePlayer {
+		miniPanelContainerPath = d2resource.MinipanelSmall
+	}
+	m.container, err = m.ui.NewSprite(miniPanelContainerPath, d2resource.PaletteSky)
+	if err != nil {
+		log.Print(err)
+		return
+	}
+	if err:=m.container.SetCurrentFrame(0); err != nil {
+		log.Print(err)
+		return
+	}
+	x, y := screenWidth/2+containerOffsetX, screenHeight+containerOffsetY
+	m.container.SetPosition(x, y)
+	m.panelGroup.AddWidget(m.container)
+
+
+	buttonWidth, buttonHeight, err := m.sprite.GetFrameSize(0)
+	if err != nil {
+		log.Print(err)
+		return
+	}
+
+	buttonWidth++
+
+	x, y = screenWidth/2 + buttonOffsetX, screenHeight + buttonOffsetY - buttonHeight
+	buttonsFirst := []struct{t d2ui.ButtonType; f func()} {
+		{d2ui.ButtonTypeMinipanelCharacter, actions.characterToggle},
+		{d2ui.ButtonTypeMinipanelInventory, actions.inventoryToggle},
+		{d2ui.ButtonTypeMinipanelSkill, actions.skilltreeToggle},
+	}
+
+	for i := range buttonsFirst {
+		btn := m.ui.NewButton(buttonsFirst[i].t, "")
+		btn.SetPosition(x + (i * buttonWidth), y)
+		btn.OnActivated(buttonsFirst[i].f)
+		m.panelGroup.AddWidget(btn)
+	}
+	idxOffset := len(buttonsFirst)
+
+	if !m.isSinglePlayer {
+		partyButton := m.ui.NewButton(d2ui.ButtonTypeMinipanelParty, "")
+		partyButton.SetPosition(x + (3 * buttonWidth), y)
+		partyButton.OnActivated(actions.partyToggle)
+		m.panelGroup.AddWidget(partyButton)
+		idxOffset += 1
+	}
+
+	buttonsLast := []struct{t d2ui.ButtonType; f func()} {
+		{d2ui.ButtonTypeMinipanelAutomap, actions.automapToggle},
+		{d2ui.ButtonTypeMinipanelMessage, actions.messageToggle },
+		{d2ui.ButtonTypeMinipanelQuest, actions.questToggle },
+		{d2ui.ButtonTypeMinipanelMen, actions.menuToggle},
+	}
+
+	for i := range buttonsLast {
+		idx := i + idxOffset
+		btn := m.ui.NewButton(buttonsLast[i].t, "")
+		btn.SetPosition(x + (idx * buttonWidth), y)
+		btn.OnActivated(buttonsLast[i].f)
+		m.panelGroup.AddWidget(btn)
+	}
+
+	m.panelGroup.SetVisible(false)
 }
 
 func (m *miniPanel) IsOpen() bool {
@@ -78,56 +143,23 @@ func (m *miniPanel) IsOpen() bool {
 }
 
 func (m *miniPanel) Toggle() {
-	m.isOpen = !m.isOpen
+	if m.isOpen {
+		m.Close()
+	} else {
+		m.Open()
+	}
 }
 
 func (m *miniPanel) Open() {
+	m.panelGroup.SetVisible(true)
 	m.isOpen = true
 }
 
 func (m *miniPanel) Close() {
+	m.panelGroup.SetVisible(false)
 	m.isOpen = false
 }
 
-func (m *miniPanel) Render(target d2interface.Surface) {
-	if !m.isOpen {
-		return
-	}
-
-	if err := m.container.SetCurrentFrame(0); err != nil {
-		return
-	}
-
-	width, height := target.GetSize()
-	halfW := width >> 1
-	x, y := halfW+containerOffsetX, height+containerOffsetY
-
-	m.container.SetPosition(x, y)
-
-	m.container.Render(target)
-
-	buttonWidth, _ := m.button.GetCurrentFrameSize()
-	buttonWidth++
-
-	for i, j := 0, 0; j < 16; i++ {
-		if m.isSinglePlayer && j == 6 { // skip Party Screen button if the game is single player
-			j += 2
-		}
-
-		if err := m.button.SetCurrentFrame(j); err != nil {
-			return
-		}
-
-		offsetX := buttonOffsetX + (buttonWidth * i)
-		x, y := halfW+offsetX, height+buttonOffsetY
-
-		m.button.SetPosition(x, y)
-		m.button.Render(target)
-
-		j += 2
-	}
-}
-
-func (m *miniPanel) isInRect(x, y int) bool {
-	return m.rectangle.IsInRect(x, y)
+func (m *miniPanel) IsInRect(px, py int) bool {
+	return m.panelGroup.Contains(px, py)
 }

--- a/d2game/d2player/mini_panel.go
+++ b/d2game/d2player/mini_panel.go
@@ -9,10 +9,8 @@ import (
 )
 
 const (
-	miniPanelX      = 325
-	miniPanelY      = 526
-	miniPanelWidth  = 156
-	miniPanelHeight = 26
+	miniPanelX = 325
+	miniPanelY = 526
 
 	panelOffsetLeft  = 130
 	panelOffsetRight = 130
@@ -51,7 +49,7 @@ type miniPanel struct {
 
 func newMiniPanel(asset *d2asset.AssetManager, uiManager *d2ui.UIManager, isSinglePlayer bool) *miniPanel {
 	return &miniPanel{
-		ui: uiManager,
+		ui:             uiManager,
 		asset:          asset,
 		isOpen:         false,
 		isSinglePlayer: isSinglePlayer,
@@ -80,19 +78,22 @@ func (m *miniPanel) createWidgets(actions *miniPanelActions) {
 	if m.isSinglePlayer {
 		miniPanelContainerPath = d2resource.MinipanelSmall
 	}
+
 	m.container, err = m.ui.NewSprite(miniPanelContainerPath, d2resource.PaletteSky)
 	if err != nil {
 		log.Print(err)
 		return
 	}
-	if err:=m.container.SetCurrentFrame(0); err != nil {
+
+	if err = m.container.SetCurrentFrame(0); err != nil {
 		log.Print(err)
 		return
 	}
+
+	// nolint:golint,gomnd // divide by 2 does not need a magic number
 	x, y := screenWidth/2+containerOffsetX, screenHeight+containerOffsetY
 	m.container.SetPosition(x, y)
 	m.panelGroup.AddWidget(m.container)
-
 
 	buttonWidth, buttonHeight, err := m.sprite.GetFrameSize(0)
 	if err != nil {
@@ -102,8 +103,12 @@ func (m *miniPanel) createWidgets(actions *miniPanelActions) {
 
 	buttonWidth++
 
-	x, y = screenWidth/2 + buttonOffsetX, screenHeight + buttonOffsetY - buttonHeight
-	buttonsFirst := []struct{t d2ui.ButtonType; f func()} {
+	// nolint:golint,gomnd // divide by 2 does not need a magic number
+	x, y = screenWidth/2+buttonOffsetX, screenHeight+buttonOffsetY-buttonHeight
+	buttonsFirst := []struct {
+		t d2ui.ButtonType
+		f func()
+	}{
 		{d2ui.ButtonTypeMinipanelCharacter, actions.characterToggle},
 		{d2ui.ButtonTypeMinipanelInventory, actions.inventoryToggle},
 		{d2ui.ButtonTypeMinipanelSkill, actions.skilltreeToggle},
@@ -111,31 +116,35 @@ func (m *miniPanel) createWidgets(actions *miniPanelActions) {
 
 	for i := range buttonsFirst {
 		btn := m.ui.NewButton(buttonsFirst[i].t, "")
-		btn.SetPosition(x + (i * buttonWidth), y)
+		btn.SetPosition(x+(i*buttonWidth), y)
 		btn.OnActivated(buttonsFirst[i].f)
 		m.panelGroup.AddWidget(btn)
 	}
+
 	idxOffset := len(buttonsFirst)
 
 	if !m.isSinglePlayer {
 		partyButton := m.ui.NewButton(d2ui.ButtonTypeMinipanelParty, "")
-		partyButton.SetPosition(x + (3 * buttonWidth), y)
+		partyButton.SetPosition(x+(3*buttonWidth), y)
 		partyButton.OnActivated(actions.partyToggle)
 		m.panelGroup.AddWidget(partyButton)
-		idxOffset += 1
+		idxOffset++
 	}
 
-	buttonsLast := []struct{t d2ui.ButtonType; f func()} {
+	buttonsLast := []struct {
+		t d2ui.ButtonType
+		f func()
+	}{
 		{d2ui.ButtonTypeMinipanelAutomap, actions.automapToggle},
-		{d2ui.ButtonTypeMinipanelMessage, actions.messageToggle },
-		{d2ui.ButtonTypeMinipanelQuest, actions.questToggle },
+		{d2ui.ButtonTypeMinipanelMessage, actions.messageToggle},
+		{d2ui.ButtonTypeMinipanelQuest, actions.questToggle},
 		{d2ui.ButtonTypeMinipanelMen, actions.menuToggle},
 	}
 
 	for i := range buttonsLast {
 		idx := i + idxOffset
 		btn := m.ui.NewButton(buttonsLast[i].t, "")
-		btn.SetPosition(x + (idx * buttonWidth), y)
+		btn.SetPosition(x+(idx*buttonWidth), y)
 		btn.OnActivated(buttonsLast[i].f)
 		m.panelGroup.AddWidget(btn)
 	}
@@ -185,13 +194,12 @@ func (m *miniPanel) undoMoveLeft() {
 	m.panelGroup.OffsetPosition(panelOffsetLeft, 0)
 }
 
-
 func (m *miniPanel) SetMovedLeft(moveLeft bool) {
 	if m.movedLeft == moveLeft {
 		return
 	}
 
-	if m.movedRight == true {
+	if m.movedRight {
 		if moveLeft {
 			m.undoMoveRight()
 			m.panelGroup.SetVisible(false)
@@ -215,7 +223,7 @@ func (m *miniPanel) SetMovedRight(moveRight bool) {
 		return
 	}
 
-	if m.movedLeft == true {
+	if m.movedLeft {
 		if moveRight {
 			m.undoMoveLeft()
 			m.panelGroup.SetVisible(false)
@@ -233,4 +241,3 @@ func (m *miniPanel) SetMovedRight(moveRight bool) {
 
 	m.movedRight = moveRight
 }
-

--- a/d2game/d2player/mini_panel.go
+++ b/d2game/d2player/mini_panel.go
@@ -13,6 +13,9 @@ const (
 	miniPanelY      = 526
 	miniPanelWidth  = 156
 	miniPanelHeight = 26
+
+	panelOffsetLeft  = 130
+	panelOffsetRight = 130
 )
 
 const (
@@ -41,6 +44,8 @@ type miniPanel struct {
 	sprite         *d2ui.Sprite
 	isOpen         bool
 	isSinglePlayer bool
+	movedLeft      bool
+	movedRight     bool
 	panelGroup     *d2ui.WidgetGroup
 }
 
@@ -163,3 +168,61 @@ func (m *miniPanel) Close() {
 func (m *miniPanel) IsInRect(px, py int) bool {
 	return m.panelGroup.Contains(px, py)
 }
+
+func (m *miniPanel) moveRight() {
+	m.panelGroup.OffsetPosition(panelOffsetRight, 0)
+}
+
+func (m *miniPanel) undoMoveRight() {
+	m.panelGroup.OffsetPosition(-panelOffsetRight, 0)
+}
+
+func (m *miniPanel) moveLeft() {
+	m.panelGroup.OffsetPosition(-panelOffsetLeft, 0)
+}
+
+func (m *miniPanel) undoMoveLeft() {
+	m.panelGroup.OffsetPosition(panelOffsetLeft, 0)
+}
+
+
+func (m *miniPanel) SetMovedLeft(moveLeft bool) {
+	if m.movedRight == true {
+		if moveLeft {
+			m.undoMoveRight()
+			m.panelGroup.SetVisible(false)
+		} else {
+			m.moveRight()
+			m.panelGroup.SetVisible(true)
+		}
+	} else {
+		if moveLeft {
+			m.moveLeft()
+		} else {
+			m.undoMoveLeft()
+		}
+	}
+
+	m.movedLeft = moveLeft
+}
+
+func (m *miniPanel) SetMovedRight(moveRight bool) {
+	if m.movedLeft == true {
+		if moveRight {
+			m.undoMoveLeft()
+			m.panelGroup.SetVisible(false)
+		} else {
+			m.moveLeft()
+			m.panelGroup.SetVisible(true)
+		}
+	} else {
+		if moveRight {
+			m.moveRight()
+		} else {
+			m.undoMoveRight()
+		}
+	}
+
+	m.movedRight = moveRight
+}
+

--- a/d2game/d2player/mini_panel.go
+++ b/d2game/d2player/mini_panel.go
@@ -187,6 +187,10 @@ func (m *miniPanel) undoMoveLeft() {
 
 
 func (m *miniPanel) SetMovedLeft(moveLeft bool) {
+	if m.movedLeft == moveLeft {
+		return
+	}
+
 	if m.movedRight == true {
 		if moveLeft {
 			m.undoMoveRight()
@@ -207,6 +211,10 @@ func (m *miniPanel) SetMovedLeft(moveLeft bool) {
 }
 
 func (m *miniPanel) SetMovedRight(moveRight bool) {
+	if m.movedRight == moveRight {
+		return
+	}
+
 	if m.movedLeft == true {
 		if moveRight {
 			m.undoMoveLeft()

--- a/d2game/d2player/skilltree.go
+++ b/d2game/d2player/skilltree.go
@@ -357,6 +357,7 @@ func (s *skillTree) Open() {
 	s.isOpen = true
 
 	s.panelGroup.SetVisible(true)
+	s.iconGroup.SetVisible(true)
 
 	// we only want to enable the icons of our current tab again
 	s.setTab(s.selectedTab)


### PR DESCRIPTION
Hi,

this refactors the minipanel to only use widgets. Extra features to the minipanel: 
* offsetting the minipanel if other panels (skilltree/inv/hero_stats) are opened.
* temp. hiding the minipanel if the esc menu is opened

This also fixes a few problems with WidgetGroups, I introduced in the last PR.

**Feel free to squash this PR**

cheers,