### PR TITLE
Ui hud polishing

### DIFF
--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -721,7 +721,6 @@ func (v *Button) SetPosition(x, y int) {
 // SetTooltip adds a tooltip to the button
 func (v *Button) SetTooltip(t *Tooltip) {
 	v.tooltip = t
-	v.manager.addWidget(t)
 	v.OnHoverStart(func() { log.Print("HoverStart"); v.tooltip.SetVisible(true) })
 	v.OnHoverEnd(func() { v.tooltip.SetVisible(false) })
 }

--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -644,7 +644,12 @@ func (v *Button) Render(target d2interface.Surface) {
 	case !v.enabled:
 		target.PushColor(d2util.Color(v.buttonLayout.DisabledColor))
 		defer target.Pop()
-		target.Render(v.disabledSurface)
+
+		if v.toggled {
+			target.Render(v.toggledSurface)
+		} else {
+			target.Render(v.disabledSurface)
+		}
 	case v.toggled && v.pressed:
 		target.Render(v.pressedToggledSurface)
 	case v.pressed:

--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -131,7 +131,6 @@ const (
 	buttonSkillTreeTabFixedHeight   = 107
 
 	buttonMinipanelOpenCloseBaseFrame = 0
-	buttonMinipanelDisabledFrame      = 2
 	buttonMinipanelXSegments          = 1
 	buttonMinipanelYSegments          = 1
 

--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -721,7 +721,7 @@ func (v *Button) SetPosition(x, y int) {
 // SetTooltip adds a tooltip to the button
 func (v *Button) SetTooltip(t *Tooltip) {
 	v.tooltip = t
-	v.OnHoverStart(func() { log.Print("HoverStart"); v.tooltip.SetVisible(true) })
+	v.OnHoverStart(func() { v.tooltip.SetVisible(true) })
 	v.OnHoverEnd(func() { v.tooltip.SetVisible(false) })
 }
 

--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -649,6 +649,11 @@ func (v *Button) Toggle() {
 	v.toggled = !v.toggled
 }
 
+// GetToggled returns the toggled state of the button
+func (v *Button) GetToggled() bool {
+	return v.toggled
+}
+
 // Advance advances the button state
 func (v *Button) Advance(_ float64) error {
 	return nil

--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -278,7 +278,7 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelOpenClose: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
-			DisabledFrame:    buttonMinipanelDisabledFrame,
+			DisabledFrame:    buttonMinipanelOpenCloseBaseFrame,
 			DisabledColor:    whiteAlpha100,
 			BaseFrame:        buttonMinipanelOpenCloseBaseFrame,
 			ResourceName:     d2resource.MenuButton,

--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -294,6 +294,8 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelCharacter: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelCharacterBaseFrame,
+			DisabledColor:    whiteAlpha100,
 			BaseFrame:        buttonMinipanelCharacterBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -308,6 +310,8 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelInventory: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelInventoryBaseFrame,
+			DisabledColor:    whiteAlpha100,
 			BaseFrame:        buttonMinipanelInventoryBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -322,6 +326,8 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelSkill: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelSkilltreeBaseFrame,
+			DisabledColor:    whiteAlpha100,
 			BaseFrame:        buttonMinipanelSkilltreeBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -336,6 +342,8 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelParty: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelPartyBaseFrame,
+			DisabledColor:    whiteAlpha100,
 			BaseFrame:        buttonMinipanelPartyBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -350,6 +358,8 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelAutomap: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelAutomapBaseFrame,
+			DisabledColor:    whiteAlpha100,
 			BaseFrame:        buttonMinipanelAutomapBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -364,6 +374,8 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelMessage: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelMessageBaseFrame,
+			DisabledColor:    whiteAlpha100,
 			BaseFrame:        buttonMinipanelMessageBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -378,6 +390,8 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelQuest: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelQuestBaseFrame,
+			DisabledColor:    whiteAlpha100,
 			BaseFrame:        buttonMinipanelQuestBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,
@@ -392,6 +406,8 @@ func getButtonLayouts() map[ButtonType]ButtonLayout {
 		ButtonTypeMinipanelMen: {
 			XSegments:        buttonMinipanelXSegments,
 			YSegments:        buttonMinipanelYSegments,
+			DisabledFrame:    buttonMinipanelMenBaseFrame,
+			DisabledColor:    whiteAlpha100,
 			BaseFrame:        buttonMinipanelMenBaseFrame,
 			ResourceName:     d2resource.MinipanelButton,
 			PaletteName:      d2resource.PaletteSky,

--- a/d2core/d2ui/custom_widget.go
+++ b/d2core/d2ui/custom_widget.go
@@ -53,7 +53,6 @@ func (c *CustomWidget) Render(target d2interface.Surface) {
 
 func (c *CustomWidget) SetTooltip(t *Tooltip) {
 	c.tooltip = t
-	c.manager.addWidget(t)
 	c.OnHoverStart(func() { c.tooltip.SetVisible(true) })
 	c.OnHoverEnd(func() { c.tooltip.SetVisible(false) })
 }

--- a/d2core/d2ui/custom_widget.go
+++ b/d2core/d2ui/custom_widget.go
@@ -11,6 +11,7 @@ type CustomWidget struct {
 	renderFunc func(target d2interface.Surface)
 	cached     bool
 	cachedImg  *d2interface.Surface
+	tooltip    *Tooltip
 }
 
 // NewCustomWidgetCached creates a new widget and caches anything rendered via the
@@ -48,6 +49,13 @@ func (c *CustomWidget) Render(target d2interface.Surface) {
 	} else {
 		c.renderFunc(target)
 	}
+}
+
+func (c *CustomWidget) SetTooltip(t *Tooltip) {
+	c.tooltip = t
+	c.manager.addWidget(t)
+	c.OnHoverStart(func() { c.tooltip.SetVisible(true) })
+	c.OnHoverEnd(func() { c.tooltip.SetVisible(false) })
 }
 
 // Advance is a no-op

--- a/d2core/d2ui/custom_widget.go
+++ b/d2core/d2ui/custom_widget.go
@@ -51,6 +51,7 @@ func (c *CustomWidget) Render(target d2interface.Surface) {
 	}
 }
 
+// SetTooltip gives this widget a Tooltip that is displayed if the widget is hovered
 func (c *CustomWidget) SetTooltip(t *Tooltip) {
 	c.tooltip = t
 	c.OnHoverStart(func() { c.tooltip.SetVisible(true) })

--- a/d2core/d2ui/tooltip.go
+++ b/d2core/d2ui/tooltip.go
@@ -69,6 +69,7 @@ func (ui *UIManager) NewTooltip(font,
 		boxEnabled:      true,
 	}
 	res.manager = ui
+	ui.addTooltip(res)
 
 	return res
 }

--- a/d2core/d2ui/tooltip.go
+++ b/d2core/d2ui/tooltip.go
@@ -58,6 +58,7 @@ func (ui *UIManager) NewTooltip(font,
 	label.Alignment = HorizontalAlignCenter
 
 	base := NewBaseWidget(ui)
+	base.SetVisible(false)
 
 	res := &Tooltip{
 		BaseWidget:      base,

--- a/d2core/d2ui/ui_manager.go
+++ b/d2core/d2ui/ui_manager.go
@@ -52,6 +52,10 @@ func (ui *UIManager) Reset() {
 	ui.pressedWidget = nil
 }
 
+func (ui *UIManager) addClickable(widget ClickableWidget) {
+	ui.clickableWidgets = append(ui.clickableWidgets, widget)
+}
+
 // addWidget adds a widget to the UI manager
 func (ui *UIManager) addWidget(widget Widget) {
 	err := ui.inputManager.BindHandler(widget)
@@ -61,12 +65,11 @@ func (ui *UIManager) addWidget(widget Widget) {
 
 	clickable, ok := widget.(ClickableWidget)
 	if ok {
-		ui.clickableWidgets = append(ui.clickableWidgets, clickable)
+		ui.addClickable(clickable)
 	}
 
 	if widgetGroup, ok := widget.(*WidgetGroup); ok {
 		ui.widgetsGroups = append(ui.widgetsGroups, widgetGroup)
-		ui.clickableWidgets = append(ui.clickableWidgets, widgetGroup.getClickableWidgets()...)
 	}
 
 	ui.widgets = append(ui.widgets, widget)

--- a/d2core/d2ui/ui_manager.go
+++ b/d2core/d2ui/ui_manager.go
@@ -68,10 +68,6 @@ func (ui *UIManager) addWidget(widget Widget) {
 		log.Print(err)
 	}
 
-	if tooltip, ok := widget.(*Tooltip); ok {
-		ui.addTooltip(tooltip)
-	}
-
 	clickable, ok := widget.(ClickableWidget)
 	if ok {
 		ui.clickableWidgets = append(ui.clickableWidgets, clickable)

--- a/d2core/d2ui/ui_manager.go
+++ b/d2core/d2ui/ui_manager.go
@@ -18,6 +18,7 @@ type UIManager struct {
 	inputManager     d2interface.InputManager
 	audio            d2interface.AudioProvider
 	widgets          []Widget
+	tooltips         []*Tooltip
 	widgetsGroups    []*WidgetGroup
 	clickableWidgets []ClickableWidget
 	cursorButtons    CursorButton
@@ -67,6 +68,10 @@ func (ui *UIManager) addWidget(widget Widget) {
 		log.Print(err)
 	}
 
+	if tooltip, ok := widget.(*Tooltip); ok {
+		ui.addTooltip(tooltip)
+	}
+
 	clickable, ok := widget.(ClickableWidget)
 	if ok {
 		ui.clickableWidgets = append(ui.clickableWidgets, clickable)
@@ -74,6 +79,11 @@ func (ui *UIManager) addWidget(widget Widget) {
 
 	ui.widgets = append(ui.widgets, widget)
 	widget.bindManager(ui)
+}
+
+// addTooltip adds a widget to the UI manager
+func (ui *UIManager) addTooltip(t *Tooltip) {
+	ui.tooltips = append(ui.tooltips, t)
 }
 
 // OnMouseButtonUp is an event handler for input
@@ -149,6 +159,12 @@ func (ui *UIManager) Render(target d2interface.Surface) {
 	for _, widget := range ui.widgets {
 		if widget.GetVisible() {
 			widget.Render(target)
+		}
+	}
+
+	for _, tooltip := range ui.tooltips {
+		if tooltip.GetVisible() {
+			tooltip.Render(target)
 		}
 	}
 }

--- a/d2core/d2ui/widget.go
+++ b/d2core/d2ui/widget.go
@@ -13,6 +13,7 @@ const (
 	RenderPriorityMinipanel
 	RenderPriorityHeroStatsPanel
 	RenderPriorityHelpPanel
+	RenderPriorityHUDPanel
 	RenderPriorityForeground
 )
 

--- a/d2core/d2ui/widget.go
+++ b/d2core/d2ui/widget.go
@@ -12,8 +12,8 @@ const (
 	RenderPrioritySkilltreeIcon
 	RenderPriorityMinipanel
 	RenderPriorityHeroStatsPanel
-	RenderPriorityHelpPanel
 	RenderPriorityHUDPanel
+	RenderPriorityHelpPanel
 	RenderPriorityForeground
 )
 

--- a/d2core/d2ui/widget.go
+++ b/d2core/d2ui/widget.go
@@ -4,18 +4,15 @@ package d2ui
 // The higher the number the later an element is drawn.
 type RenderPriority int
 
+// Render priorities that determine the order in which widgets/widgetgroups are
+// rendered. The higher the later it is rendered
 const (
-	// RenderPriorityBackground is the first element drawn
 	RenderPriorityBackground RenderPriority = iota
-	// RenderPrioritySkilltree is the priority for the skilltree
 	RenderPrioritySkilltree
-	// RenderPrioritySkilltreeIcon is the priority for the skilltree icons
 	RenderPrioritySkilltreeIcon
-	// RenderPriorityMinipanel is the priority for the minipanel icons
 	RenderPriorityMinipanel
-	// RenderPriorityHeroStatsPanel is the priority for the hero_stats_panel
 	RenderPriorityHeroStatsPanel
-	// RenderPriorityForeground is the last element drawn
+	RenderPriorityHelpPanel
 	RenderPriorityForeground
 )
 

--- a/d2core/d2ui/widget.go
+++ b/d2core/d2ui/widget.go
@@ -10,9 +10,9 @@ const (
 	RenderPriorityBackground RenderPriority = iota
 	RenderPrioritySkilltree
 	RenderPrioritySkilltreeIcon
-	RenderPriorityMinipanel
 	RenderPriorityHeroStatsPanel
 	RenderPriorityHUDPanel
+	RenderPriorityMinipanel
 	RenderPriorityHelpPanel
 	RenderPriorityForeground
 )

--- a/d2core/d2ui/widget_group.go
+++ b/d2core/d2ui/widget_group.go
@@ -28,7 +28,7 @@ func (ui *UIManager) NewWidgetGroup(priority RenderPriority) *WidgetGroup {
 		BaseWidget: base,
 	}
 
-	ui.addWidgetGroup(group)
+	ui.addWidget(group)
 
 	return group
 }
@@ -136,3 +136,14 @@ func (wg *WidgetGroup) SetEnabled(enabled bool) {
 		}
 	}
 }
+
+func (wg *WidgetGroup) getClickableWidgets() []ClickableWidget {
+	var res []ClickableWidget
+	for _, entry := range wg.entries {
+		if v, ok := entry.(ClickableWidget); ok {
+			res = append(res, v)
+		}
+	}
+	return res
+}
+

--- a/d2core/d2ui/widget_group.go
+++ b/d2core/d2ui/widget_group.go
@@ -40,6 +40,10 @@ func (wg *WidgetGroup) AddWidget(w Widget) {
 	sort.SliceStable(wg.entries, func(i, j int) bool {
 		return wg.entries[i].GetRenderPriority() < wg.entries[j].GetRenderPriority()
 	})
+
+	if clickable, ok := w.(ClickableWidget); ok {
+		wg.manager.addClickable(clickable)
+	}
 }
 
 // adjustSize recalculates the bounding box if a new widget is added
@@ -136,14 +140,3 @@ func (wg *WidgetGroup) SetEnabled(enabled bool) {
 		}
 	}
 }
-
-func (wg *WidgetGroup) getClickableWidgets() []ClickableWidget {
-	var res []ClickableWidget
-	for _, entry := range wg.entries {
-		if v, ok := entry.(ClickableWidget); ok {
-			res = append(res, v)
-		}
-	}
-	return res
-}
-

--- a/d2core/d2ui/widget_group.go
+++ b/d2core/d2ui/widget_group.go
@@ -127,3 +127,12 @@ func (wg *WidgetGroup) OnMouseMove(x, y int) {
 		}
 	}
 }
+
+// SetEnabled sets enable on all clickable widgets of this group
+func (wg *WidgetGroup) SetEnabled(enabled bool) {
+	for _, entry := range wg.entries {
+		if v, ok := entry.(ClickableWidget); ok {
+			v.SetEnabled(enabled)
+		}
+	}
+}

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -674,6 +674,7 @@ func (g *GameControls) Load() {
 // Advance advances the state of the GameControls
 func (g *GameControls) Advance(elapsed float64) error {
 	g.mapRenderer.Advance(elapsed)
+	g.hud.Advance(elapsed)
 
 	if err := g.escapeMenu.Advance(elapsed); err != nil {
 		return err

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -219,8 +219,8 @@ func NewGameControls(
 		return nil, err
 	}
 
-	helpOverlay := NewHelpOverlay(asset, renderer, ui, guiManager, l, keyMap)
-	hud := NewHUD(asset, ui, hero, helpOverlay, miniPanel, actionableRegions, mapEngine, l, mapRenderer)
+	helpOverlay := NewHelpOverlay(asset, ui, l, keyMap)
+	hud := NewHUD(asset, ui, hero, miniPanel, actionableRegions, mapEngine, l, mapRenderer)
 
 	const blackAlpha50percent = 0x0000007f
 
@@ -271,6 +271,7 @@ func NewGameControls(
 	gc.skilltree.SetOnCloseCb(gc.onCloseSkilltree)
 
 	gc.escapeMenu.SetOnCloseCb(gc.hud.miniPanel.restoreDisabled)
+	gc.HelpOverlay.SetOnCloseCb(gc.hud.miniPanel.restoreDisabled)
 
 	err = gc.bindTerminalCommands(term)
 	if err != nil {
@@ -397,6 +398,8 @@ func (g *GameControls) OnKeyDown(event d2interface.KeyEvent) bool {
 	case d2enum.HoldRun:
 		g.hud.onToggleRunButton(true)
 	case d2enum.ToggleHelpScreen:
+		g.hud.miniPanel.openDisabled()
+
 		g.HelpOverlay.Toggle()
 		g.updateLayout()
 	default:

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -270,7 +270,7 @@ func NewGameControls(
 	gc.inventory.SetOnCloseCb(gc.onCloseInventory)
 	gc.skilltree.SetOnCloseCb(gc.onCloseSkilltree)
 
-	gc.escapeMenu.SetOnCloseCb(gc.hud.restoreMinipanelFromTempClose)
+	gc.escapeMenu.SetOnCloseCb(gc.hud.miniPanel.restoreDisabled)
 
 	err = gc.bindTerminalCommands(term)
 	if err != nil {
@@ -646,7 +646,7 @@ func (g *GameControls) openEscMenu() {
 	g.inventory.Close()
 	g.skilltree.Close()
 	g.heroStatsPanel.Close()
-	g.hud.closeMinipanelTemporary()
+	g.hud.miniPanel.closeDisabled()
 	g.escapeMenu.open()
 	g.updateLayout()
 }

--- a/d2game/d2player/globeWidget.go
+++ b/d2game/d2player/globeWidget.go
@@ -43,6 +43,9 @@ const (
 // static check that globeWidget implements Widget
 var _ d2ui.Widget = &globeWidget{}
 
+// static check that globeWidget implements ClickableWidget
+var _ d2ui.ClickableWidget = &globeWidget{}
+
 type globeFrame struct {
 	sprite  *d2ui.Sprite
 	offsetX int
@@ -109,13 +112,23 @@ func newGlobeWidget(ui *d2ui.UIManager, asset *d2asset.AssetManager, x, y int, g
 		valueMax:   valueMax,
 		globe:      globe,
 		overlap:    overlap,
+		isTooltipLocked: false,
 		tooltipX:   tooltipX,
 		tooltipY:   tooltipY,
 		tooltipTrans: tooltipTrans,
 	}
 
-	gw.OnHoverStart(func() { gw.tooltip.SetVisible(true) })
-	gw.OnHoverEnd(func() { gw.tooltip.SetVisible(false) })
+	gw.OnHoverStart(func() {
+		if !gw.isTooltipLocked {
+			gw.tooltip.SetVisible(true)
+		}
+	})
+
+	gw.OnHoverEnd(func() {
+		if !gw.isTooltipLocked {
+			gw.tooltip.SetVisible(false)
+		}
+	})
 
 	gw.logger = d2util.NewLogger()
 	gw.logger.SetLevel(l)
@@ -133,6 +146,8 @@ type globeWidget struct {
 	overlap  *globeFrame
 	logger   *d2util.Logger
 
+	pressed  bool
+	isTooltipLocked bool
 	tooltip  *d2ui.Tooltip
 	tooltipX int
 	tooltipY int
@@ -197,4 +212,29 @@ func (g *globeWidget) Advance(elapsed float64) error {
 	g.updateTooltip()
 
 	return nil
+}
+
+func (g *globeWidget) Activate() {
+	g.isTooltipLocked = !g.isTooltipLocked
+	g.tooltip.SetVisible(g.isTooltipLocked)
+}
+
+func (g *globeWidget) GetEnabled() bool {
+	return true
+}
+
+func (g *globeWidget) SetEnabled(enable bool) {
+	// No-op
+}
+
+func (g *globeWidget) GetPressed() bool {
+	return g.pressed
+}
+
+func (g *globeWidget) SetPressed(pressed bool) {
+	g.pressed = pressed
+}
+
+func (g *globeWidget) OnActivated(callback func()) {
+	// No-op
 }

--- a/d2game/d2player/globeWidget.go
+++ b/d2game/d2player/globeWidget.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2resource"
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2util"
+	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2ui"
 )
 
@@ -64,14 +64,16 @@ func (gf *globeFrame) setPosition(x, y int) {
 	gf.sprite.SetPosition(x+gf.offsetX, y+gf.offsetY)
 }
 
-func (gf *globeFrame) getSize() (x, y int) {
-	w, h := gf.sprite.GetSize()
-	return w + gf.offsetX, h + gf.offsetY
-}
-
-func newGlobeWidget(ui *d2ui.UIManager, asset *d2asset.AssetManager, x, y int, gtype globeType, value *int, l d2util.LogLevel, valueMax *int) *globeWidget {
+func newGlobeWidget(ui *d2ui.UIManager,
+	asset *d2asset.AssetManager,
+	x, y int,
+	gtype globeType,
+	value *int, valueMax *int,
+	l d2util.LogLevel) *globeWidget {
 	var globe, overlap *globeFrame
+
 	var tooltipX, tooltipY int
+
 	var tooltipTrans string
 
 	base := d2ui.NewBaseWidget(ui)
@@ -106,16 +108,16 @@ func newGlobeWidget(ui *d2ui.UIManager, asset *d2asset.AssetManager, x, y int, g
 	}
 
 	gw := &globeWidget{
-		BaseWidget: base,
-		asset:      asset,
-		value:      value,
-		valueMax:   valueMax,
-		globe:      globe,
-		overlap:    overlap,
+		BaseWidget:      base,
+		asset:           asset,
+		value:           value,
+		valueMax:        valueMax,
+		globe:           globe,
+		overlap:         overlap,
 		isTooltipLocked: false,
-		tooltipX:   tooltipX,
-		tooltipY:   tooltipY,
-		tooltipTrans: tooltipTrans,
+		tooltipX:        tooltipX,
+		tooltipY:        tooltipY,
+		tooltipTrans:    tooltipTrans,
 	}
 
 	gw.OnHoverStart(func() {
@@ -146,12 +148,12 @@ type globeWidget struct {
 	overlap  *globeFrame
 	logger   *d2util.Logger
 
-	pressed  bool
+	pressed         bool
 	isTooltipLocked bool
-	tooltip  *d2ui.Tooltip
-	tooltipX int
-	tooltipY int
-	tooltipTrans string
+	tooltip         *d2ui.Tooltip
+	tooltipX        int
+	tooltipY        int
+	tooltipTrans    string
 }
 
 func (g *globeWidget) load() {
@@ -197,9 +199,8 @@ func (g *globeWidget) Contains(px, py int) bool {
 	wx, wy := g.globe.sprite.GetPosition()
 	width, height := g.globe.sprite.GetSize()
 
-	return px >= wx && px <= wx + width && py <= wy && py >= wy - height
+	return px >= wx && px <= wx+width && py <= wy && py >= wy-height
 }
-
 
 func (g *globeWidget) updateTooltip() {
 	// Create and format string from string lookup table.

--- a/d2game/d2player/help_overlay.go
+++ b/d2game/d2player/help_overlay.go
@@ -163,9 +163,9 @@ func NewHelpOverlay(
 	keyMap *KeyMap,
 ) *HelpOverlay {
 	h := &HelpOverlay{
-		asset:      asset,
-		uiManager:  ui,
-		keyMap:     keyMap,
+		asset:     asset,
+		uiManager: ui,
+		keyMap:    keyMap,
 	}
 
 	h.logger = d2util.NewLogger()
@@ -177,16 +177,16 @@ func NewHelpOverlay(
 
 // HelpOverlay represents the in-game overlay that toggles visibility when the h key is pressed
 type HelpOverlay struct {
-	asset       *d2asset.AssetManager
-	isOpen      bool
-	frames      []*d2ui.Sprite
-	text        []*d2ui.Label
-	lines       []line
-	uiManager   *d2ui.UIManager
-	closeButton *d2ui.Button
-	keyMap      *KeyMap
-	onCloseCb   func()
-	panelGroup  *d2ui.WidgetGroup
+	asset            *d2asset.AssetManager
+	isOpen           bool
+	frames           []*d2ui.Sprite
+	text             []*d2ui.Label
+	lines            []line
+	uiManager        *d2ui.UIManager
+	closeButton      *d2ui.Button
+	keyMap           *KeyMap
+	onCloseCb        func()
+	panelGroup       *d2ui.WidgetGroup
 	backgroundWidget *d2ui.CustomWidget
 
 	logger *d2util.Logger

--- a/d2game/d2player/help_overlay.go
+++ b/d2game/d2player/help_overlay.go
@@ -322,6 +322,7 @@ func (h *HelpOverlay) setupTitleAndButton() {
 	h.closeButton.SetPosition(closeButtonX, closeButtonY)
 	h.closeButton.SetVisible(false)
 	h.closeButton.OnActivated(func() { h.Close() })
+	h.closeButton.SetRenderPriority(d2ui.RenderPriorityForeground)
 	h.panelGroup.AddWidget(h.closeButton)
 
 	newLabel = h.uiManager.NewLabel(d2resource.Font16, d2resource.PaletteSky)

--- a/d2game/d2player/help_overlay.go
+++ b/d2game/d2player/help_overlay.go
@@ -10,7 +10,6 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2util"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2gui"
 	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2ui"
 )
 
@@ -159,17 +158,13 @@ const (
 // NewHelpOverlay creates a new HelpOverlay instance
 func NewHelpOverlay(
 	asset *d2asset.AssetManager,
-	renderer d2interface.Renderer,
 	ui *d2ui.UIManager,
-	guiManager *d2gui.GuiManager,
 	l d2util.LogLevel,
 	keyMap *KeyMap,
 ) *HelpOverlay {
 	h := &HelpOverlay{
 		asset:      asset,
-		renderer:   renderer,
 		uiManager:  ui,
-		guiManager: guiManager,
 		keyMap:     keyMap,
 	}
 
@@ -184,15 +179,15 @@ func NewHelpOverlay(
 type HelpOverlay struct {
 	asset       *d2asset.AssetManager
 	isOpen      bool
-	renderer    d2interface.Renderer
 	frames      []*d2ui.Sprite
 	text        []*d2ui.Label
 	lines       []line
 	uiManager   *d2ui.UIManager
-	layout      *d2gui.Layout
 	closeButton *d2ui.Button
-	guiManager  *d2gui.GuiManager
 	keyMap      *KeyMap
+	onCloseCb   func()
+	panelGroup  *d2ui.WidgetGroup
+	backgroundWidget *d2ui.CustomWidget
 
 	logger *d2util.Logger
 }
@@ -211,20 +206,18 @@ func (h *HelpOverlay) Toggle() {
 // Close will hide the help overlay
 func (h *HelpOverlay) Close() {
 	h.isOpen = false
-	h.closeButton.SetVisible(false)
-	h.guiManager.SetLayout(nil)
+	h.panelGroup.SetVisible(false)
+	h.onCloseCb()
+}
+
+// SetOnCloseCb sets the callback run when Close() is called
+func (h *HelpOverlay) SetOnCloseCb(cb func()) {
+	h.onCloseCb = cb
 }
 
 func (h *HelpOverlay) open() {
 	h.isOpen = true
-	if h.layout == nil {
-		h.layout = d2gui.CreateLayout(h.renderer, d2gui.PositionTypeHorizontal, h.asset)
-	}
-
-	h.closeButton.SetVisible(true)
-	h.closeButton.SetPressed(false)
-
-	h.guiManager.SetLayout(h.layout)
+	h.panelGroup.SetVisible(true)
 }
 
 // IsOpen returns whether or not the overlay is visible/open
@@ -234,22 +227,21 @@ func (h *HelpOverlay) IsOpen() bool {
 
 // IsInRect checks if the given point is within the overlay layout rectangle
 func (h *HelpOverlay) IsInRect(px, py int) bool {
-	ww, hh := h.layout.GetSize()
-	x, y := h.layout.GetPosition()
-
-	if px >= x && px <= x+ww && py >= y && py <= y+hh {
-		return true
-	}
-
-	return false
+	return h.panelGroup.Contains(px, py)
 }
 
 // Load the overlay graphical assets
 func (h *HelpOverlay) Load() {
+	h.panelGroup = h.uiManager.NewWidgetGroup(d2ui.RenderPriorityHelpPanel)
+
 	h.setupOverlayFrame()
 	h.setupTitleAndButton()
 	h.setupBulletedList()
 	h.setupLabelsWithLines()
+
+	h.backgroundWidget = h.uiManager.NewCustomWidgetCached(h.Render, screenWidth, screenHeight)
+	h.panelGroup.AddWidget(h.backgroundWidget)
+	h.panelGroup.SetVisible(false)
 }
 
 func (h *HelpOverlay) setupOverlayFrame() {
@@ -330,6 +322,7 @@ func (h *HelpOverlay) setupTitleAndButton() {
 	h.closeButton.SetPosition(closeButtonX, closeButtonY)
 	h.closeButton.SetVisible(false)
 	h.closeButton.OnActivated(func() { h.Close() })
+	h.panelGroup.AddWidget(h.closeButton)
 
 	newLabel = h.uiManager.NewLabel(d2resource.Font16, d2resource.PaletteSky)
 	newLabel.SetText(h.asset.TranslateString("strClose")) // "Close"
@@ -621,11 +614,7 @@ func (h *HelpOverlay) createCallout(c callout) {
 }
 
 // Render the overlay to the given surface
-func (h *HelpOverlay) Render(target d2interface.Surface) error {
-	if !h.isOpen {
-		return nil
-	}
-
+func (h *HelpOverlay) Render(target d2interface.Surface) {
 	for _, f := range h.frames {
 		f.Render(target)
 	}
@@ -639,6 +628,4 @@ func (h *HelpOverlay) Render(target d2interface.Surface) error {
 		target.DrawLine(l.MoveX, l.MoveY, l.Color)
 		target.Pop()
 	}
-
-	return nil
 }

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -176,9 +176,9 @@ func (h *HUD) Load() {
 	h.manaGlobe.SetRenderPriority(d2ui.RenderPriorityForeground)
 	h.panelGroup.AddWidget(h.manaGlobe)
 
+	h.loadTooltips()
 	h.loadSkillResources()
 	h.loadCustomWidgets()
-	h.loadTooltips()
 	h.loadUIButtons()
 
 	h.panelGroup.SetVisible(true)
@@ -583,21 +583,13 @@ func (h *HUD) renderRunWalkTooltip(target d2interface.Surface) {
 	h.runWalkTooltip.Render(target)
 }
 
-func (h *HUD) renderStaminaTooltip(target d2interface.Surface) {
-	mx, my := h.lastMouseX, h.lastMouseY
-
-	// Display stamina tooltip when hovered.
-	if !h.actionableRegions[stamina].rect.IsInRect(mx, my) {
-		return
-	}
-
+func (h *HUD) setStaminaTooltipText() {
 	// Create and format Stamina string from string lookup table.
 	fmtStamina := h.asset.TranslateString("panelstamina")
 	staminaCurr, staminaMax := int(h.hero.Stats.Stamina), h.hero.Stats.MaxStamina
 	strPanelStamina := fmt.Sprintf(fmtStamina, staminaCurr, staminaMax)
 
 	h.staminaTooltip.SetText(strPanelStamina)
-	h.staminaTooltip.Render(target)
 }
 
 func (h *HUD) renderExperienceTooltip(target d2interface.Surface) {
@@ -674,7 +666,6 @@ func (h *HUD) Render(target d2interface.Surface) error {
 	h.renderHealthTooltip(target)
 	h.renderManaTooltip(target)
 	h.renderRunWalkTooltip(target)
-	h.renderStaminaTooltip(target)
 	h.renderExperienceTooltip(target)
 
 	if h.skillSelectMenu.IsOpen() {
@@ -702,6 +693,10 @@ func (h *HUD) getSkillResourceByClass(class string) string {
 	}
 
 	return entry
+}
+
+func (h *HUD) Advance(elapsed float64) {
+	h.setStaminaTooltipText()
 }
 
 // OnMouseMove handles mouse move events

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -311,6 +311,7 @@ func (h *HUD) loadUIButtons() {
 	h.runButton.OnActivated(func() { h.onToggleRunButton(false) })
 	h.runButton.SetTooltip(h.runWalkTooltip)
 	h.updateRunTooltipText()
+	h.panelGroup.AddWidget(h.runButton)
 
 	if h.hero.IsRunToggled() {
 		h.runButton.Toggle()

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -204,6 +204,8 @@ func (h *HUD) loadCustomWidgets() {
 
 	// experience bar
 	h.widgetExperience = h.uiManager.NewCustomWidget(h.renderExperienceBar, expBarWidth, expBarHeight)
+	h.widgetExperience.SetPosition(experienceBarOffsetX, experienceBarOffsetY)
+	h.widgetExperience.SetTooltip(h.experienceTooltip)
 	h.panelGroup.AddWidget(h.widgetExperience)
 
 	// Left skill widget
@@ -592,14 +594,7 @@ func (h *HUD) setStaminaTooltipText() {
 	h.staminaTooltip.SetText(strPanelStamina)
 }
 
-func (h *HUD) renderExperienceTooltip(target d2interface.Surface) {
-	mx, my := h.lastMouseX, h.lastMouseY
-
-	// Display experience tooltip when hovered.
-	if !h.actionableRegions[xp].rect.IsInRect(mx, my) {
-		return
-	}
-
+func (h *HUD) setExperienceTooltipText() {
 	// Create and format Experience string from string lookup table.
 	fmtExp := h.asset.TranslateString("panelexp")
 
@@ -613,7 +608,6 @@ func (h *HUD) renderExperienceTooltip(target d2interface.Surface) {
 	strPanelExp := fmt.Sprintf(fmtExp, expCurr, expMax)
 
 	h.experienceTooltip.SetText(strPanelExp)
-	h.experienceTooltip.Render(target)
 }
 
 func (h *HUD) renderForSelectableEntitiesHovered(target d2interface.Surface) {
@@ -666,7 +660,6 @@ func (h *HUD) Render(target d2interface.Surface) error {
 	h.renderHealthTooltip(target)
 	h.renderManaTooltip(target)
 	h.renderRunWalkTooltip(target)
-	h.renderExperienceTooltip(target)
 
 	if h.skillSelectMenu.IsOpen() {
 		h.skillSelectMenu.Render(target)
@@ -697,6 +690,7 @@ func (h *HUD) getSkillResourceByClass(class string) string {
 
 func (h *HUD) Advance(elapsed float64) {
 	h.setStaminaTooltipText()
+	h.setExperienceTooltipText()
 }
 
 // OnMouseMove handles mouse move events

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -307,13 +307,25 @@ func (h *HUD) loadTooltips() {
 func (h *HUD) loadUIButtons() {
 	// Run button
 	h.runButton = h.uiManager.NewButton(d2ui.ButtonTypeRun, "")
-
 	h.runButton.SetPosition(runButtonX, runButtonY)
 	h.runButton.OnActivated(func() { h.onToggleRunButton(false) })
+	h.runButton.SetTooltip(h.runWalkTooltip)
+	h.updateRunTooltipText()
 
 	if h.hero.IsRunToggled() {
 		h.runButton.Toggle()
 	}
+}
+
+func (h *HUD) updateRunTooltipText() {
+	var stringTableKey string
+	if h.hero.IsRunToggled() {
+		stringTableKey = "RunOff"
+	} else {
+		stringTableKey = "RunOn"
+	}
+
+	h.runWalkTooltip.SetText(h.asset.TranslateString(stringTableKey))
 }
 
 func (h *HUD) onToggleRunButton(noButton bool) {
@@ -322,6 +334,7 @@ func (h *HUD) onToggleRunButton(noButton bool) {
 	}
 
 	h.hero.ToggleRunWalk()
+	h.updateRunTooltipText()
 
 	// https://github.com/OpenDiablo2/OpenDiablo2/issues/800
 	h.hero.SetIsRunning(h.hero.IsRunToggled())
@@ -508,27 +521,6 @@ func (h *HUD) renderNewSkillsButton(x, _ int, target d2interface.Surface) error 
 	return nil
 }
 
-func (h *HUD) renderRunWalkTooltip(target d2interface.Surface) {
-	mx, my := h.lastMouseX, h.lastMouseY
-
-	// Display run/walk tooltip when hovered.
-	// Note that whether the player is walking or running, the tooltip is the same in Diablo 2.
-	if !h.actionableRegions[walkRun].rect.IsInRect(mx, my) {
-		return
-	}
-
-	var stringTableKey string
-
-	if h.hero.IsRunToggled() {
-		stringTableKey = "RunOff"
-	} else {
-		stringTableKey = "RunOn"
-	}
-
-	h.runWalkTooltip.SetText(h.asset.TranslateString(stringTableKey))
-	h.runWalkTooltip.Render(target)
-}
-
 func (h *HUD) setStaminaTooltipText() {
 	// Create and format Stamina string from string lookup table.
 	fmtStamina := h.asset.TranslateString("panelstamina")
@@ -600,8 +592,6 @@ func (h *HUD) Render(target d2interface.Surface) error {
 		h.zoneChangeText.SetPosition(zoneChangeTextX, zoneChangeTextY)
 		h.zoneChangeText.Render(target)
 	}
-
-	h.renderRunWalkTooltip(target)
 
 	if h.skillSelectMenu.IsOpen() {
 		h.skillSelectMenu.Render(target)

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -92,7 +92,6 @@ type HUD struct {
 	hero               *d2mapentity.Player
 	mainPanel          *d2ui.Sprite
 	globeSprite        *d2ui.Sprite
-	menuButton         *d2ui.Button
 	hpManaStatusSprite *d2ui.Sprite
 	leftSkillResource  *SkillResource
 	rightSkillResource *SkillResource
@@ -109,7 +108,6 @@ type HUD struct {
 	experienceTooltip  *d2ui.Tooltip
 	healthTooltip      *d2ui.Tooltip
 	manaTooltip        *d2ui.Tooltip
-	miniPanelTooltip   *d2ui.Tooltip
 	nameLabel          *d2ui.Label
 	healthGlobe        *globeWidget
 	manaGlobe          *globeWidget
@@ -310,10 +308,6 @@ func (h *HUD) loadTooltips() {
 	h.manaTooltip = h.uiManager.NewTooltip(d2resource.Font16, d2resource.PaletteUnits, d2ui.TooltipXLeft, d2ui.TooltipYTop)
 	h.manaTooltip.SetPosition(manaLabelX, manaLabelY)
 	h.manaTooltip.SetBoxEnabled(false)
-
-	// minipanel open/close tooltip
-	h.miniPanelTooltip = h.uiManager.NewTooltip(d2resource.Font16, d2resource.PaletteUnits, d2ui.TooltipXCenter, d2ui.TooltipYTop)
-	h.miniPanelTooltip.SetPosition(screenWidth/2+miniPanelButtonOffsetX+miniPanelTooltipOffsetX, screenHeight+miniPanelButtonOffsetY+miniPanelTooltipOffsetY)
 }
 
 func (h *HUD) loadUIButtons() {
@@ -326,31 +320,6 @@ func (h *HUD) loadUIButtons() {
 	if h.hero.IsRunToggled() {
 		h.runButton.Toggle()
 	}
-
-	// minipanel button
-	h.menuButton = h.uiManager.NewButton(d2ui.ButtonTypeMinipanelOpenClose, "")
-	//nolint:golint,gomnd // 2 is not a magic number
-	x := screenWidth/2 + miniPanelButtonOffsetX
-	y := screenHeight + miniPanelButtonOffsetY
-	h.menuButton.SetPosition(x, y)
-	h.menuButton.OnActivated(func() {
-		h.menuButton.Toggle()
-		h.miniPanel.Toggle()
-		h.updateMinipanelTooltipText()
-	})
-	h.menuButton.SetTooltip(h.miniPanelTooltip)
-	h.updateMinipanelTooltipText()
-}
-
-func (h *HUD) updateMinipanelTooltipText() {
-	var stringTableKey string
-	if h.menuButton.GetToggled() {
-		stringTableKey = "panelcmini"
-	} else {
-		stringTableKey = "panelmini"
-	}
-
-	h.miniPanelTooltip.SetText(h.asset.TranslateString(stringTableKey))
 }
 
 func (h *HUD) onToggleRunButton(noButton bool) {
@@ -745,21 +714,4 @@ func (h *HUD) OnMouseMove(event d2interface.MouseMoveEvent) bool {
 	h.skillSelectMenu.RightPanel.HandleMouseMove(mx, my)
 
 	return false
-}
-
-func (h *HUD) closeMinipanelTemporary() {
-	h.isMiniPanelOpen = h.miniPanel.IsOpen()
-	if h.isMiniPanelOpen {
-		h.menuButton.SetEnabled(false)
-		h.menuButton.Toggle()
-		h.miniPanel.Close()
-	}
-}
-
-func (h *HUD) restoreMinipanelFromTempClose() {
-	if h.isMiniPanelOpen {
-		h.menuButton.SetEnabled(true)
-		h.menuButton.Toggle()
-		h.miniPanel.Open()
-	}
 }

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -115,6 +115,7 @@ type HUD struct {
 	widgetLeftSkill    *d2ui.CustomWidget
 	widgetRightSkill   *d2ui.CustomWidget
 	panelBackground    *d2ui.CustomWidget
+	panelGroup         *d2ui.WidgetGroup
 	logger             *d2util.Logger
 }
 
@@ -163,15 +164,24 @@ func NewHUD(
 
 // Load creates the ui elemets
 func (h *HUD) Load() {
+	h.panelGroup = h.uiManager.NewWidgetGroup(d2ui.RenderPriorityHUDPanel)
+
 	h.loadSprites()
 
 	h.healthGlobe.load()
+	h.healthGlobe.SetRenderPriority(d2ui.RenderPriorityForeground)
+	h.panelGroup.AddWidget(h.healthGlobe)
+
 	h.manaGlobe.load()
+	h.manaGlobe.SetRenderPriority(d2ui.RenderPriorityForeground)
+	h.panelGroup.AddWidget(h.manaGlobe)
 
 	h.loadSkillResources()
 	h.loadCustomWidgets()
 	h.loadTooltips()
 	h.loadUIButtons()
+
+	h.panelGroup.SetVisible(true)
 }
 
 func (h *HUD) loadCustomWidgets() {
@@ -184,13 +194,17 @@ func (h *HUD) loadCustomWidgets() {
 
 	h.panelBackground = h.uiManager.NewCustomWidgetCached(h.renderPanelStatic, screenWidth, height)
 	h.panelBackground.SetPosition(0, screenHeight-height)
+	h.panelGroup.AddWidget(h.panelBackground)
 
 	// stamina bar
 	h.widgetStamina = h.uiManager.NewCustomWidget(h.renderStaminaBar, staminaBarWidth, staminaBarHeight)
 	h.widgetStamina.SetPosition(staminaBarOffsetX, staminaBarOffsetY)
+	h.widgetStamina.SetTooltip(h.staminaTooltip)
+	h.panelGroup.AddWidget(h.widgetStamina)
 
 	// experience bar
 	h.widgetExperience = h.uiManager.NewCustomWidget(h.renderExperienceBar, expBarWidth, expBarHeight)
+	h.panelGroup.AddWidget(h.widgetExperience)
 
 	// Left skill widget
 	leftRenderFunc := func(target d2interface.Surface) {
@@ -200,6 +214,7 @@ func (h *HUD) loadCustomWidgets() {
 
 	h.widgetLeftSkill = h.uiManager.NewCustomWidget(leftRenderFunc, skillIconWidth, skillIconHeight)
 	h.widgetLeftSkill.SetPosition(leftSkillX, screenHeight)
+	h.panelGroup.AddWidget(h.widgetLeftSkill)
 
 	// Right skill widget
 	rightRenderFunc := func(target d2interface.Surface) {
@@ -209,6 +224,7 @@ func (h *HUD) loadCustomWidgets() {
 
 	h.widgetRightSkill = h.uiManager.NewCustomWidget(rightRenderFunc, skillIconWidth, skillIconHeight)
 	h.widgetRightSkill.SetPosition(rightSkillX, screenHeight)
+	h.panelGroup.AddWidget(h.widgetRightSkill)
 }
 
 func (h *HUD) loadSkillResources() {
@@ -649,15 +665,6 @@ func (h *HUD) renderForSelectableEntitiesHovered(target d2interface.Surface) {
 // Render draws the HUD to the screen
 func (h *HUD) Render(target d2interface.Surface) error {
 	h.renderForSelectableEntitiesHovered(target)
-
-	h.panelBackground.Render(target)
-
-	h.healthGlobe.Render(target)
-	h.widgetLeftSkill.Render(target)
-	h.widgetRightSkill.Render(target)
-	h.manaGlobe.Render(target)
-	h.widgetStamina.Render(target)
-	h.widgetExperience.Render(target)
 
 	if h.isZoneTextShown {
 		h.zoneChangeText.SetPosition(zoneChangeTextX, zoneChangeTextY)

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -47,8 +47,8 @@ const (
 )
 
 const (
-	staminaBarOffsetX = 273
-	staminaBarOffsetY = 572
+	staminaBarOffsetX  = 273
+	staminaBarOffsetY  = 572
 	staminaExperienceY = 535
 
 	experienceBarOffsetX = 256
@@ -88,7 +88,6 @@ type HUD struct {
 	runButton          *d2ui.Button
 	zoneChangeText     *d2ui.Label
 	miniPanel          *miniPanel
-	isMiniPanelOpen    bool
 	isZoneTextShown    bool
 	hpStatsIsVisible   bool
 	manaStatsIsVisible bool
@@ -126,8 +125,16 @@ func NewHUD(
 	zoneLabel := ui.NewLabel(d2resource.Font30, d2resource.PaletteUnits)
 	zoneLabel.Alignment = d2ui.HorizontalAlignCenter
 
-	healthGlobe := newGlobeWidget(ui, asset, 0, screenHeight, typeHealthGlobe, &hero.Stats.Health, l, &hero.Stats.MaxHealth)
-	manaGlobe := newGlobeWidget(ui, asset, screenWidth-manaGlobeScreenOffsetX, screenHeight, typeManaGlobe, &hero.Stats.Mana, l, &hero.Stats.MaxMana)
+	healthGlobe := newGlobeWidget(ui, asset,
+		0, screenHeight,
+		typeHealthGlobe,
+		&hero.Stats.Health, &hero.Stats.MaxHealth,
+		l)
+	manaGlobe := newGlobeWidget(ui, asset,
+		screenWidth-manaGlobeScreenOffsetX, screenHeight,
+		typeManaGlobe,
+		&hero.Stats.Mana, &hero.Stats.MaxMana,
+		l)
 
 	hud := &HUD{
 		asset:             asset,
@@ -621,11 +628,19 @@ func (h *HUD) getSkillResourceByClass(class string) string {
 	return entry
 }
 
+// Advance updates syncs data on widgets that might have changed. I.e. the current stamina value
+// in the stamina tooltip
 func (h *HUD) Advance(elapsed float64) {
 	h.setStaminaTooltipText()
 	h.setExperienceTooltipText()
-	h.healthGlobe.Advance(elapsed)
-	h.manaGlobe.Advance(elapsed)
+
+	if err := h.healthGlobe.Advance(elapsed); err != nil {
+		h.logger.Error(err.Error())
+	}
+
+	if err := h.manaGlobe.Advance(elapsed); err != nil {
+		h.logger.Error(err.Error())
+	}
 }
 
 // OnMouseMove handles mouse move events

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -68,6 +68,9 @@ const (
 
 	miniPanelButtonOffsetX = -8
 	miniPanelButtonOffsetY = -38
+
+	miniPanelTooltipOffsetX = 7
+	miniPanelTooltipOffsetY = -14
 )
 
 const (
@@ -172,8 +175,8 @@ func (h *HUD) Load() {
 
 	h.loadSkillResources()
 	h.loadCustomWidgets()
-	h.loadUIButtons()
 	h.loadTooltips()
+	h.loadUIButtons()
 }
 
 func (h *HUD) loadCustomWidgets() {
@@ -308,8 +311,9 @@ func (h *HUD) loadTooltips() {
 	h.manaTooltip.SetPosition(manaLabelX, manaLabelY)
 	h.manaTooltip.SetBoxEnabled(false)
 
-	// minipanel tooltip
+	// minipanel open/close tooltip
 	h.miniPanelTooltip = h.uiManager.NewTooltip(d2resource.Font16, d2resource.PaletteUnits, d2ui.TooltipXCenter, d2ui.TooltipYTop)
+	h.miniPanelTooltip.SetPosition(screenWidth/2+miniPanelButtonOffsetX+miniPanelTooltipOffsetX, screenHeight+miniPanelButtonOffsetY+miniPanelTooltipOffsetY)
 }
 
 func (h *HUD) loadUIButtons() {
@@ -332,7 +336,21 @@ func (h *HUD) loadUIButtons() {
 	h.menuButton.OnActivated(func() {
 		h.menuButton.Toggle()
 		h.miniPanel.Toggle()
+		h.updateMinipanelTooltipText()
 	})
+	h.menuButton.SetTooltip(h.miniPanelTooltip)
+	h.updateMinipanelTooltipText()
+}
+
+func (h *HUD) updateMinipanelTooltipText() {
+	var stringTableKey string
+	if h.menuButton.GetToggled() {
+		stringTableKey = "panelcmini"
+	} else {
+		stringTableKey = "panelmini"
+	}
+
+	h.miniPanelTooltip.SetText(h.asset.TranslateString(stringTableKey))
 }
 
 func (h *HUD) onToggleRunButton(noButton bool) {

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -84,7 +84,6 @@ type HUD struct {
 	actionableRegions  []actionableRegion
 	asset              *d2asset.AssetManager
 	uiManager          *d2ui.UIManager
-	help               *HelpOverlay
 	mapEngine          *d2mapengine.MapEngine
 	mapRenderer        *d2maprenderer.MapRenderer
 	lastMouseX         int
@@ -124,7 +123,6 @@ func NewHUD(
 	asset *d2asset.AssetManager,
 	ui *d2ui.UIManager,
 	hero *d2mapentity.Player,
-	help *HelpOverlay,
 	miniPanel *miniPanel,
 	actionableRegions []actionableRegion,
 	mapEngine *d2mapengine.MapEngine,
@@ -145,7 +143,6 @@ func NewHUD(
 		asset:             asset,
 		uiManager:         ui,
 		hero:              hero,
-		help:              help,
 		mapEngine:         mapEngine,
 		mapRenderer:       mapRenderer,
 		miniPanel:         miniPanel,
@@ -661,10 +658,6 @@ func (h *HUD) Render(target d2interface.Surface) error {
 	h.manaGlobe.Render(target)
 	h.widgetStamina.Render(target)
 	h.widgetExperience.Render(target)
-
-	if err := h.help.Render(target); err != nil {
-		return err
-	}
 
 	if h.isZoneTextShown {
 		h.zoneChangeText.SetPosition(zoneChangeTextX, zoneChangeTextY)

--- a/d2game/d2player/mini_panel.go
+++ b/d2game/d2player/mini_panel.go
@@ -73,6 +73,7 @@ type miniPanel struct {
 	movedRight     bool
 	panelGroup     *d2ui.WidgetGroup
 	groupAlwaysVis *d2ui.WidgetGroup
+	tooltipGroup   *d2ui.WidgetGroup
 
 	logger *d2util.Logger
 }
@@ -96,6 +97,8 @@ func (m *miniPanel) createWidgets(actions *miniPanelActions) {
 	m.panelGroup.SetPosition(miniPanelX, miniPanelY)
 
 	m.groupAlwaysVis = m.ui.NewWidgetGroup(d2ui.RenderPriorityMinipanel)
+
+	m.tooltipGroup = m.ui.NewWidgetGroup(d2ui.RenderPriorityForeground)
 
 	// container sprite
 	miniPanelContainerPath := d2resource.Minipanel
@@ -214,6 +217,7 @@ func (m *miniPanel) createButton(content miniPanelContent, x, y, buttonHeight in
 	tt.SetPosition(x, y-buttonHeight)
 	tt.SetText(content.tooltip)
 	tt.SetVisible(false)
+	m.tooltipGroup.AddWidget(tt)
 
 	// Button
 	btn := m.ui.NewButton(content.buttonType, "")
@@ -276,6 +280,7 @@ func (m *miniPanel) IsInRect(px, py int) bool {
 
 func (m *miniPanel) moveRight() {
 	m.panelGroup.OffsetPosition(panelOffsetRight, 0)
+	m.tooltipGroup.OffsetPosition(panelOffsetRight, 0)
 }
 
 func (m *miniPanel) undoMoveRight() {
@@ -284,10 +289,12 @@ func (m *miniPanel) undoMoveRight() {
 
 func (m *miniPanel) moveLeft() {
 	m.panelGroup.OffsetPosition(-panelOffsetLeft, 0)
+	m.tooltipGroup.OffsetPosition(-panelOffsetLeft, 0)
 }
 
 func (m *miniPanel) undoMoveLeft() {
 	m.panelGroup.OffsetPosition(panelOffsetLeft, 0)
+	m.tooltipGroup.OffsetPosition(panelOffsetLeft, 0)
 }
 
 func (m *miniPanel) SetMovedLeft(moveLeft bool) {

--- a/d2game/d2player/mini_panel.go
+++ b/d2game/d2player/mini_panel.go
@@ -249,7 +249,9 @@ func (m *miniPanel) Toggle() {
 }
 
 func (m *miniPanel) Open() {
-	m.panelGroup.SetVisible(true)
+	if !m.movedLeft && !m.movedRight {
+		m.panelGroup.SetVisible(true)
+	}
 
 	if !m.menuButton.GetToggled() {
 		m.menuButton.Toggle()
@@ -299,7 +301,7 @@ func (m *miniPanel) SetMovedLeft(moveLeft bool) {
 			m.panelGroup.SetVisible(false)
 		} else {
 			m.moveRight()
-			m.panelGroup.SetVisible(true)
+			m.panelGroup.SetVisible(m.isOpen)
 		}
 	} else {
 		if moveLeft {
@@ -323,7 +325,7 @@ func (m *miniPanel) SetMovedRight(moveRight bool) {
 			m.panelGroup.SetVisible(false)
 		} else {
 			m.moveLeft()
-			m.panelGroup.SetVisible(true)
+			m.panelGroup.SetVisible(m.isOpen)
 		}
 	} else {
 		if moveRight {

--- a/d2game/d2player/mini_panel.go
+++ b/d2game/d2player/mini_panel.go
@@ -59,21 +59,21 @@ func newMiniPanel(asset *d2asset.AssetManager,
 }
 
 type miniPanel struct {
-	ui             *d2ui.UIManager
-	asset          *d2asset.AssetManager
-	container      *d2ui.Sprite
-	sprite         *d2ui.Sprite
-	menuButton     *d2ui.Button
-	miniPanelTooltip   *d2ui.Tooltip
-	isOpen         bool
-	tempIsOpen     bool
-	disabled       bool
-	isSinglePlayer bool
-	movedLeft      bool
-	movedRight     bool
-	panelGroup     *d2ui.WidgetGroup
-	groupAlwaysVis *d2ui.WidgetGroup
-	tooltipGroup   *d2ui.WidgetGroup
+	ui               *d2ui.UIManager
+	asset            *d2asset.AssetManager
+	container        *d2ui.Sprite
+	sprite           *d2ui.Sprite
+	menuButton       *d2ui.Button
+	miniPanelTooltip *d2ui.Tooltip
+	isOpen           bool
+	tempIsOpen       bool
+	disabled         bool
+	isSinglePlayer   bool
+	movedLeft        bool
+	movedRight       bool
+	panelGroup       *d2ui.WidgetGroup
+	groupAlwaysVis   *d2ui.WidgetGroup
+	tooltipGroup     *d2ui.WidgetGroup
 
 	logger *d2util.Logger
 }
@@ -121,6 +121,14 @@ func (m *miniPanel) createWidgets(actions *miniPanelActions) {
 	x, y := screenWidth/2+containerOffsetX, screenHeight+containerOffsetY
 	m.container.SetPosition(x, y)
 	m.panelGroup.AddWidget(m.container)
+
+	m.createButtons(actions)
+
+	m.panelGroup.SetVisible(false)
+}
+
+func (m *miniPanel) createButtons(actions *miniPanelActions) {
+	var x, y int
 
 	buttonWidth, buttonHeight, err := m.sprite.GetFrameSize(0)
 	if err != nil {
@@ -189,6 +197,7 @@ func (m *miniPanel) createWidgets(actions *miniPanelActions) {
 		m.panelGroup.AddWidget(btn)
 	}
 
+	//nolint:gomnd // divide by 2 is not a magic number
 	x = screenWidth/2 + miniPanelButtonOffsetX
 	y = screenHeight + miniPanelButtonOffsetY
 	// minipanel open/close tooltip
@@ -197,18 +206,12 @@ func (m *miniPanel) createWidgets(actions *miniPanelActions) {
 
 	// minipanel button
 	m.menuButton = m.ui.NewButton(d2ui.ButtonTypeMinipanelOpenClose, "")
-	//nolint:golint,gomnd // 2 is not a magic number
 	m.menuButton.SetPosition(x, y)
-	m.menuButton.OnActivated(func() {
-		m.menuButton.Toggle()
-		m.Toggle()
-		m.updateMinipanelTooltipText()
-	})
+	m.menuButton.OnActivated(m.onMenuButtonClicked)
+
 	m.menuButton.SetTooltip(m.miniPanelTooltip)
 	m.updateMinipanelTooltipText()
 	m.groupAlwaysVis.AddWidget(m.menuButton)
-
-	m.panelGroup.SetVisible(false)
 }
 
 func (m *miniPanel) createButton(content miniPanelContent, x, y, buttonHeight int) *d2ui.Button {
@@ -227,6 +230,12 @@ func (m *miniPanel) createButton(content miniPanelContent, x, y, buttonHeight in
 	btn.SetRenderPriority(d2ui.RenderPriorityForeground)
 
 	return btn
+}
+
+func (m *miniPanel) onMenuButtonClicked() {
+	m.menuButton.Toggle()
+	m.Toggle()
+	m.updateMinipanelTooltipText()
 }
 
 func (m *miniPanel) updateMinipanelTooltipText() {

--- a/d2game/d2player/mini_panel.go
+++ b/d2game/d2player/mini_panel.go
@@ -72,7 +72,7 @@ type miniPanel struct {
 	movedLeft      bool
 	movedRight     bool
 	panelGroup     *d2ui.WidgetGroup
-	tooltipGroup   *d2ui.WidgetGroup
+	groupAlwaysVis *d2ui.WidgetGroup
 
 	logger *d2util.Logger
 }
@@ -95,7 +95,7 @@ func (m *miniPanel) createWidgets(actions *miniPanelActions) {
 	m.panelGroup = m.ui.NewWidgetGroup(d2ui.RenderPriorityMinipanel)
 	m.panelGroup.SetPosition(miniPanelX, miniPanelY)
 
-	m.tooltipGroup = m.ui.NewWidgetGroup(d2ui.RenderPriorityForeground)
+	m.groupAlwaysVis = m.ui.NewWidgetGroup(d2ui.RenderPriorityMinipanel)
 
 	// container sprite
 	miniPanelContainerPath := d2resource.Minipanel
@@ -203,6 +203,7 @@ func (m *miniPanel) createWidgets(actions *miniPanelActions) {
 	})
 	m.menuButton.SetTooltip(m.miniPanelTooltip)
 	m.updateMinipanelTooltipText()
+	m.groupAlwaysVis.AddWidget(m.menuButton)
 
 	m.panelGroup.SetVisible(false)
 }
@@ -213,13 +214,13 @@ func (m *miniPanel) createButton(content miniPanelContent, x, y, buttonHeight in
 	tt.SetPosition(x, y-buttonHeight)
 	tt.SetText(content.tooltip)
 	tt.SetVisible(false)
-	m.tooltipGroup.AddWidget(tt)
 
 	// Button
 	btn := m.ui.NewButton(content.buttonType, "")
 	btn.SetPosition(x, y)
 	btn.OnActivated(content.onActivate)
 	btn.SetTooltip(tt)
+	btn.SetRenderPriority(d2ui.RenderPriorityForeground)
 
 	return btn
 }
@@ -273,22 +274,18 @@ func (m *miniPanel) IsInRect(px, py int) bool {
 
 func (m *miniPanel) moveRight() {
 	m.panelGroup.OffsetPosition(panelOffsetRight, 0)
-	m.tooltipGroup.OffsetPosition(panelOffsetRight, 0)
 }
 
 func (m *miniPanel) undoMoveRight() {
 	m.panelGroup.OffsetPosition(-panelOffsetRight, 0)
-	m.tooltipGroup.OffsetPosition(-panelOffsetRight, 0)
 }
 
 func (m *miniPanel) moveLeft() {
 	m.panelGroup.OffsetPosition(-panelOffsetLeft, 0)
-	m.tooltipGroup.OffsetPosition(-panelOffsetLeft, 0)
 }
 
 func (m *miniPanel) undoMoveLeft() {
 	m.panelGroup.OffsetPosition(panelOffsetLeft, 0)
-	m.tooltipGroup.OffsetPosition(panelOffsetLeft, 0)
 }
 
 func (m *miniPanel) SetMovedLeft(moveLeft bool) {


### PR DESCRIPTION
Hi,

here is the next part of my ui rework. Here are the highlights:

* hero_stats, skilltree, minipanel, help_overlay and hud are now rendered in the correct order
* help_overlay converted to widgets
* tooltips are now always rendered last
* most of the hud converted to widgets
* fixed some edge cases when the mini_panel was temporary closed or moved

**Feel free to squash this PR**

cheers,