### PR TITLE
close button label in help overlay

### DIFF
--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -2,7 +2,6 @@ package d2ui
 
 import (
 	"image"
-	"log"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"

--- a/d2game/d2player/help_overlay.go
+++ b/d2game/d2player/help_overlay.go
@@ -68,7 +68,7 @@ const (
 	// the close button for the help panel
 	closeButtonX      = 685
 	closeButtonY      = 25
-	closeButtonLabelX = 680
+	closeButtonLabelX = 702
 	closeButtonLabelY = 60
 
 	// the rest of these are for text with a line and dot, towards the bottom of the screen
@@ -328,6 +328,7 @@ func (h *HelpOverlay) setupTitleAndButton() {
 	newLabel = h.uiManager.NewLabel(d2resource.Font16, d2resource.PaletteSky)
 	newLabel.SetText(h.asset.TranslateString("strClose")) // "Close"
 	newLabel.SetPosition(closeButtonLabelX, closeButtonLabelY)
+	newLabel.Alignment = d2ui.HorizontalAlignCenter
 	h.text = append(h.text, newLabel)
 }
 


### PR DESCRIPTION
Hi there,
I've noticed some minor bug (it isn't visible in english locale, but using another language, w can see it):
close button label in help overlay is alignet to left, so i another locale, where "cloes" word has another lenght it is alignet to left side of close button, so...