### PR TITLE
Fix draweffect blending selection

### DIFF
--- a/d2core/d2render/ebiten/ebiten_surface.go
+++ b/d2core/d2render/ebiten/ebiten_surface.go
@@ -146,8 +146,6 @@ func (s *ebitenSurface) RenderSprite(sprite *d2ui.Sprite) {
 
 	s.handleStateEffect(opts)
 
-	opts.CompositeMode = ebiten.CompositeModeSourceOver
-
 	sprite.Render(s)
 }
 
@@ -160,8 +158,6 @@ func (s *ebitenSurface) Render(sfc d2interface.Surface) {
 	}
 
 	s.handleStateEffect(opts)
-
-	opts.CompositeMode = ebiten.CompositeModeSourceOver
 
 	s.image.DrawImage(sfc.(*ebitenSurface).image, opts)
 }


### PR DESCRIPTION
The blending mode picked by handleStateEffect was being overriden.

CompositeModeSourceOver is the default selection, we do not need to
initialise opts with this.