### PR TITLE
d2resource - escape menu labels

### DIFF
--- a/d2common/d2resource/resource_paths.go
+++ b/d2common/d2resource/resource_paths.go
@@ -12,16 +12,6 @@ const (
 
 	LoadingScreen = "/data/global/ui/Loading/loadingscreen.dc6"
 
-	// --- Video Paths ---
-
-	Act1Intro = "/data/local/video/" + LanguageTableToken + "/d2intro640x292.bik"
-	Act2Intro = "/data/local/video/" + LanguageTableToken + "/act02start640x292.bik"
-	Act3Intro = "/data/local/video/" + LanguageTableToken + "/act03start640x292.bik"
-	Act4Intro = "/data/local/video/" + LanguageTableToken + "/act04start640x292.bik"
-	Act4Outro = "/data/local/video/" + LanguageTableToken + "/act04end640x292.bik"
-	Act5Intro = "/data/local/video/" + LanguageTableToken + "/d2x_intro_640x292.bik"
-	Act5Outro = "/data/local/video/" + LanguageTableToken + "/d2x_out_640x292.bik"
-
 	// --- Main Menu ---
 
 	TrademarkScreen       = "/data/global/ui/FrontEnd/trademarkscreenEXP.dc6"
@@ -40,6 +30,16 @@ const (
 	// --- Cinematics ---
 
 	CinematicsBackground = "/data/global/ui/FrontEnd/CinematicsSelectionEXP.dc6"
+
+	// --- Video Paths ---
+
+	Act1Intro = "/data/local/video/" + LanguageTableToken + "/d2intro640x292.bik"
+	Act2Intro = "/data/local/video/" + LanguageTableToken + "/act02start640x292.bik"
+	Act3Intro = "/data/local/video/" + LanguageTableToken + "/act03start640x292.bik"
+	Act4Intro = "/data/local/video/" + LanguageTableToken + "/act04start640x292.bik"
+	Act4Outro = "/data/local/video/" + LanguageTableToken + "/act04end640x292.bik"
+	Act5Intro = "/data/local/video/" + LanguageTableToken + "/d2x_intro_640x292.bik"
+	Act5Outro = "/data/local/video/" + LanguageTableToken + "/d2x_out_640x292.bik"
 
 	// --- Character Select Screen ---
 
@@ -109,6 +109,56 @@ const (
 	GameGlobeOverlap    = "/data/global/ui/PANEL/overlap.DC6"
 	HealthManaIndicator = "/data/global/ui/PANEL/hlthmana.DC6"
 	AddSkillButton      = "/data/global/ui/PANEL/level.DC6"
+
+	// --- Escape Menu ---
+	// main
+	EscapeOptions      = "/data/local/ui/" + LanguageTableToken + "/options.dc6"
+	EscapeExit         = "/data/local/ui/" + LanguageTableToken + "/exit.dc6"
+	EscapeReturnToGame = "/data/local/ui/" + LanguageTableToken + "/returntogame.dc6"
+	// options
+	EscapeOptSoundOptions   = "/data/local/ui/" + LanguageTableToken + "/soundoptions.dc6"
+	EscapeOptVideoOptions   = "/data/local/ui/" + LanguageTableToken + "/videoOptions.dc6"
+	EscapeOptAutoMapOptions = "/data/local/ui/" + LanguageTableToken + "/automapOptions.dc6"
+	EscapeOptCfgOptions     = "/data/local/ui/" + LanguageTableToken + "/cfgOptions.dc6"
+	EscapeOptPrevious       = "/data/local/ui/" + LanguageTableToken + "/previous.dc6"
+
+	// sound options
+	EscapeSndOptSoundVolume = "/data/local/ui/" + LanguageTableToken + "/sound.dc6"
+	EscapeSndOptMusicVolume = "/data/local/ui/" + LanguageTableToken + "/music.dc6"
+	EscapeSndOpt3DBias      = "/data/local/ui/" + LanguageTableToken + "/3dbias.dc6"
+	// EscapeSndOptHWAcceleration =
+	// EscapeSndOptENVEffects =
+	EscapeSndOptNPCSpeech             = "/data/local/ui/" + LanguageTableToken + "/npcspeech.dc6"
+	EscapeSndOptNPCSpeechAudioAndText = "/data/local/ui/" + LanguageTableToken + "/audiotext.dc6"
+	EscapeSndOptNPCSpeechAudioOnly    = "/data/local/ui/" + LanguageTableToken + "/audioonly.dc6"
+	EscapeSndOptNPCSpeechTextOnly     = "/data/local/ui/" + LanguageTableToken + "/textonly.dc6"
+
+	// video options
+	EscapeVidOptRes          = "/data/local/ui/" + LanguageTableToken + "/resolution.dc6"
+	EscapeVidOptLightQuality = "/data/local/ui/" + LanguageTableToken + "/lightquality.dc6"
+	EscapeVidOptBlendShadow  = "/data/local/ui/" + LanguageTableToken + "/blendshadow.dc6"
+	EscapeVidOptPerspective  = "/data/local/ui/" + LanguageTableToken + "/prespective.dc6"
+	EscapeVidOptGamma        = "/data/local/ui/" + LanguageTableToken + "/gamma.dc6"
+	EscapeVidOptContrast     = "/data/local/ui/" + LanguageTableToken + "/contrast.dc6"
+
+	// auto map
+	EscapeAutoMapOptSize   = "/data/local/ui/" + LanguageTableToken + "/automapmode.dc6"
+	EscapeAutoMapOptFade   = "/data/local/ui/" + LanguageTableToken + "/automapfade.dc6"
+	EscapeAutoMapOptCenter = "/data/local/ui/" + LanguageTableToken + "/automapcenter.dc6"
+	EscapeAutoMapOptNames  = "/data/local/ui/" + LanguageTableToken + "/automappartynames.dc6"
+
+	// automap size
+	EscapeAutoMapOptFullScreen = "/data/local/ui/" + LanguageTableToken + "/full.dc6"
+	EscapeAutoMapOptMiniMap    = "/data/local/ui/" + LanguageTableToken + "/mini.dc6"
+
+	// resolutions
+	EscapeVideoOptRes640x480 = "/data/local/ui/" + LanguageTableToken + "/640x480.dc6"
+	EscapeVideoOptRes800x600 = "/data/local/ui/" + LanguageTableToken + "/800x800.dc6"
+
+	EscapeOn  = "/data/local/ui/" + LanguageTableToken + "/smallon.dc6"
+	EscapeOff = "/data/local/ui/" + LanguageTableToken + "/smalloff.dc6"
+	EscapeYes = "/data/local/ui/" + LanguageTableToken + "/smallyes.dc6"
+	EscapeNo  = "/data/local/ui/" + LanguageTableToken + "/smallno.dc6"
 
 	// --- Help Overlay ---
 

--- a/d2common/d2resource/resource_paths.go
+++ b/d2common/d2resource/resource_paths.go
@@ -109,6 +109,10 @@ const (
 	GameGlobeOverlap    = "/data/global/ui/PANEL/overlap.DC6"
 	HealthManaIndicator = "/data/global/ui/PANEL/hlthmana.DC6"
 	AddSkillButton      = "/data/global/ui/PANEL/level.DC6"
+	GoldMoveDialog      = "/data/global/ui/menu/dialogbackground.DC6"
+	WPTabs              = "/data/global/ui/menu/expwaygatetabs.dc6"
+	WPBg                = "/data/global/ui/menu/waygatebackground.dc6"
+	WPIcons             = "/data/global/ui/menu/waygateicons.dc6"
 
 	// --- Escape Menu ---
 	// main
@@ -155,10 +159,12 @@ const (
 	EscapeVideoOptRes640x480 = "/data/local/ui/" + LanguageTableToken + "/640x480.dc6"
 	EscapeVideoOptRes800x600 = "/data/local/ui/" + LanguageTableToken + "/800x800.dc6"
 
-	EscapeOn  = "/data/local/ui/" + LanguageTableToken + "/smallon.dc6"
-	EscapeOff = "/data/local/ui/" + LanguageTableToken + "/smalloff.dc6"
-	EscapeYes = "/data/local/ui/" + LanguageTableToken + "/smallyes.dc6"
-	EscapeNo  = "/data/local/ui/" + LanguageTableToken + "/smallno.dc6"
+	EscapeOn            = "/data/local/ui/" + LanguageTableToken + "/smallon.dc6"
+	EscapeOff           = "/data/local/ui/" + LanguageTableToken + "/smalloff.dc6"
+	EscapeYes           = "/data/local/ui/" + LanguageTableToken + "/smallyes.dc6"
+	EscapeNo            = "/data/local/ui/" + LanguageTableToken + "/smallno.dc6"
+	EscapeSlideBar      = "/data/global/ui/widgets/optbarc.dc6"
+	EscapeSlideBarSkull = "/data/global/ui/widgets/optskull.dc6"
 
 	// --- Help Overlay ---
 
@@ -178,6 +184,36 @@ const (
 	// Issue #685 - used in the mini-panel
 	GameSmallMenuButton = "/data/global/ui/PANEL/menubutton.DC6"
 	SkillIcon           = "/data/global/ui/PANEL/Skillicon.DC6"
+
+	// --- Quest Log---
+	QuestLogBg     = "/data/global/ui/menu/questbackground.dc6"
+	QuestLogDone   = "/data/global/ui/menu/questdone.dc6"
+	QuestLogQDescr = "/data/global/ui/menu/questlast.dc6"
+	QuestLogSocket = "/data/global/ui/menu/questsocket.dc6"
+	QuestLogA1Q1   = "/data/global/ui/menu/a1q1.dc6"
+	QuestLogA1Q2   = "/data/global/ui/menu/a1q2.dc6"
+	QuestLogA1Q3   = "/data/global/ui/menu/a1q3.dc6"
+	QuestLogA1Q4   = "/data/global/ui/menu/a1q4.dc6"
+	QuestLogA1Q5   = "/data/global/ui/menu/a1q5.dc6"
+	QuestLogA1Q6   = "/data/global/ui/menu/a1q6.dc6"
+	QuestLogA2Q1   = "/data/global/ui/menu/a2q1.dc6"
+	QuestLogA2Q2   = "/data/global/ui/menu/a2q2.dc6"
+	QuestLogA2Q3   = "/data/global/ui/menu/a2q3.dc6"
+	QuestLogA2Q4   = "/data/global/ui/menu/a2q4.dc6"
+	QuestLogA2Q5   = "/data/global/ui/menu/a2q5.dc6"
+	QuestLogA2Q6   = "/data/global/ui/menu/a2q6.dc6"
+	QuestLogA3Q1   = "/data/global/ui/menu/a3q1.dc6"
+	QuestLogA3Q2   = "/data/global/ui/menu/a3q2.dc6"
+	QuestLogA3Q3   = "/data/global/ui/menu/a3q3.dc6"
+	QuestLogA3Q4   = "/data/global/ui/menu/a3q4.dc6"
+	QuestLogA3Q5   = "/data/global/ui/menu/a3q5.dc6"
+	QuestLogA3Q6   = "/data/global/ui/menu/a3q6.dc6"
+	QuestLogA4Q1   = "/data/global/ui/menu/a4q1.dc6"
+	QuestLogA4Q2   = "/data/global/ui/menu/a4q2.dc6"
+	QuestLogA4Q3   = "/data/global/ui/menu/a4q3.dc6"
+	QuestLogA4Q4   = "/data/global/ui/menu/a4q4.dc6"
+	QuestLogA4Q5   = "/data/global/ui/menu/a4q5.dc6"
+	QuestLogA4Q6   = "/data/global/ui/menu/a4q6.dc6"
 
 	// --- Mouse Pointers ---
 

--- a/d2core/d2map/d2mapentity/player.go
+++ b/d2core/d2map/d2mapentity/player.go
@@ -34,8 +34,10 @@ type Player struct {
 }
 
 // run speed should be walkspeed * 1.5, since in the original game it is 6 yards walk and 9 yards run.
-const baseWalkSpeed = 6.0
-const baseRunSpeed = 9.0
+const (
+	baseWalkSpeed = 9.0
+	baseRunSpeed  = 13.0
+)
 
 // ID returns the Player uuid
 func (p *Player) ID() string {

--- a/d2game/d2player/escape_menu.go
+++ b/d2game/d2player/escape_menu.go
@@ -195,8 +195,8 @@ func (m *EscapeMenu) newOptionsLayout() *layout {
 func (m *EscapeMenu) newSoundOptionsLayout() *layout {
 	return m.wrapLayout(func(l *layout) {
 		m.addTitle(l, "SOUND OPTIONS")
-		m.addEnumLabel(l, optAudioSoundVolume, "SOUND VOLUME", []string{"TODO"})
-		m.addEnumLabel(l, optAudioMusicVolume, "MUSIC VOLUME", []string{"TODO"})
+		m.addEnumLabel(l, optAudioSoundVolume, "SOUND", []string{"TODO"})
+		m.addEnumLabel(l, optAudioMusicVolume, "MUSIC", []string{"TODO"})
 		m.addEnumLabel(l, optAudio3dSound, "3D BIAS", []string{"TODO"})
 		m.addEnumLabel(l, optAudioHardwareAcceleration, "HARDWARE ACCELERATION", []string{"ON", "OFF"})
 		m.addEnumLabel(l, optAudioEnvEffects, "ENVIRONMENTAL EFFECTS", []string{"ON", "OFF"})


### PR DESCRIPTION
Hi there,
In this PR I'm:
- adding escape menu labels to d2resource
- a bit modified escape menu labels ("sound volume" -> "sound" and "music volume -> music") to it looks like in orginal d2
- adding quest log labels to d2resources
- changing player movement speed to it looks more like in original diablo