### PR TITLE
code-cleanup: rgbaColor & terminal

### DIFF
--- a/d2core/d2gui/common.go
+++ b/d2core/d2gui/common.go
@@ -1,8 +1,6 @@
 package d2gui
 
 import (
-	"image/color"
-
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2math"
 )
@@ -36,29 +34,4 @@ func renderSegmented(animation d2interface.Animation, segmentsX, segmentsY, fram
 
 func half(n int) int {
 	return n / 2
-}
-
-func rgbaColor(rgba uint32) color.RGBA {
-	result := color.RGBA{}
-	a, b, g, r := 0, 1, 2, 3
-	byteWidth := 8
-	byteMask := 0xff
-
-	for idx := 0; idx < 4; idx++ {
-		shift := idx * byteWidth
-		component := uint8(rgba>>shift) & uint8(byteMask)
-
-		switch idx {
-		case a:
-			result.A = component
-		case b:
-			result.B = component
-		case g:
-			result.G = component
-		case r:
-			result.R = component
-		}
-	}
-
-	return result
 }

--- a/d2core/d2gui/layout.go
+++ b/d2core/d2gui/layout.go
@@ -248,16 +248,16 @@ func (l *Layout) renderEntryDebug(entry *layoutEntry, target d2interface.Surface
 	target.PushTranslation(entry.x, entry.y)
 	defer target.Pop()
 
-	drawColor := rgbaColor(white)
+	drawColor := d2util.Color(white)
 	switch entry.widget.(type) {
 	case *Layout:
-		drawColor = rgbaColor(magenta)
+		drawColor = d2util.Color(magenta)
 	case *SpacerStatic, *SpacerDynamic:
-		drawColor = rgbaColor(grey2)
+		drawColor = d2util.Color(grey2)
 	case *Label:
-		drawColor = rgbaColor(green)
+		drawColor = d2util.Color(green)
 	case *Button:
-		drawColor = rgbaColor(yellow)
+		drawColor = d2util.Color(yellow)
 	}
 
 	target.DrawLine(entry.width, 0, drawColor)
@@ -487,7 +487,7 @@ func (l *Layout) createButton(renderer d2interface.Renderer, text string,
 		return nil, loadErr
 	}
 
-	textColor := rgbaColor(grey)
+	textColor := d2util.Color(grey)
 	textWidth, textHeight := font.GetTextMetrics(text)
 	textX := half(buttonWidth) - half(textWidth)
 	textY := half(buttonHeight) - half(textHeight) + config.textOffset

--- a/d2core/d2term/terminal.go
+++ b/d2core/d2term/terminal.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2math"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2util"
 )
 
 const (
@@ -491,39 +492,14 @@ func parseCommand(command string) []string {
 	return params
 }
 
-func rgbaColor(rgba uint32) color.RGBA {
-	result := color.RGBA{}
-	a, b, g, r := 0, 1, 2, 3
-	byteWidth := 8
-	byteMask := 0xff
-
-	for idx := 0; idx < 4; idx++ {
-		shift := idx * byteWidth
-		component := uint8(rgba>>shift) & uint8(byteMask)
-
-		switch idx {
-		case a:
-			result.A = component
-		case b:
-			result.B = component
-		case g:
-			result.G = component
-		case r:
-			result.R = component
-		}
-	}
-
-	return result
-}
-
 func createTerminal() (*terminal, error) {
 	terminal := &terminal{
 		lineCount:    termRowCount,
-		bgColor:      rgbaColor(darkGrey),
-		fgColor:      rgbaColor(lightGrey),
-		infoColor:    rgbaColor(lightBlue),
-		warningColor: rgbaColor(yellow),
-		errorColor:   rgbaColor(red),
+		bgColor:      d2util.Color(darkGrey),
+		fgColor:      d2util.Color(lightGrey),
+		infoColor:    d2util.Color(lightBlue),
+		warningColor: d2util.Color(yellow),
+		errorColor:   d2util.Color(red),
 		actions:      make(map[string]termActionEntry),
 	}
 

--- a/d2core/d2term/terminal.go
+++ b/d2core/d2term/terminal.go
@@ -348,25 +348,15 @@ func parseActionParams(actionType reflect.Type, actionParams []string) ([]reflec
 }
 
 func (t *terminal) OutputRaw(text string, category d2enum.TermCategory) {
-	var line string
+	lines := d2util.SplitIntoLinesWithMaxWidth(text, termColCountMax)
 
-	for _, word := range strings.Split(text, " ") {
-		if len(line) > 0 {
-			line += " "
-		}
+	for _, line := range lines {
+		// removes color token (this token ends with [0m )
+		l := strings.Split(line, "[0m ")
+		line = l[len(l)-1]
 
-		lineLength := len(line)
-		wordLength := len(word)
-
-		if lineLength+wordLength >= termColCountMax {
-			t.outputHistory = append(t.outputHistory, termHistoryEntry{line, category})
-			line = word
-		} else {
-			line += word
-		}
+		t.outputHistory = append(t.outputHistory, termHistoryEntry{line, category})
 	}
-
-	t.outputHistory = append(t.outputHistory, termHistoryEntry{line, category})
 }
 
 func (t *terminal) Outputf(format string, params ...interface{}) {

--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -180,7 +180,7 @@ const (
 
 	blankQuestButtonXSegments      = 1
 	blankQuestButtonYSegments      = 1
-	blankQuestButtonDisabledFrames = -1
+	blankQuestButtonDisabledFrames = 0
 
 	buttonMinipanelCharacterBaseFrame = 0
 	buttonMinipanelInventoryBaseFrame = 2
@@ -900,7 +900,7 @@ func (v *Button) prerenderStates(btnSprite *Sprite, btnLayout *ButtonLayout, lab
 	label.SetPosition(xOffset, textY)
 	label.Render(v.normalSurface)
 
-	if !btnLayout.HasImage || !btnLayout.AllowFrameChange {
+	if !btnLayout.AllowFrameChange {
 		return
 	}
 
@@ -1003,7 +1003,10 @@ func (v *Button) Render(target d2interface.Surface) {
 		if v.toggled {
 			target.Render(v.toggledSurface)
 		} else {
-			target.Render(v.disabledSurface)
+			// it allows to use SetEnabled(false) for non-image budons
+			if v.buttonLayout.HasImage {
+				target.Render(v.disabledSurface)
+			}
 		}
 	case v.toggled && v.pressed:
 		target.Render(v.pressedToggledSurface)

--- a/d2core/d2ui/button.go
+++ b/d2core/d2ui/button.go
@@ -1002,11 +1002,8 @@ func (v *Button) Render(target d2interface.Surface) {
 
 		if v.toggled {
 			target.Render(v.toggledSurface)
-		} else {
-			// it allows to use SetEnabled(false) for non-image budons
-			if v.buttonLayout.HasImage {
-				target.Render(v.disabledSurface)
-			}
+		} else if v.buttonLayout.HasImage { // it allows to use SetEnabled(false) for non-image budons
+			target.Render(v.disabledSurface)
 		}
 	case v.toggled && v.pressed:
 		target.Render(v.pressedToggledSurface)

--- a/d2core/d2ui/sprite.go
+++ b/d2core/d2ui/sprite.go
@@ -74,7 +74,7 @@ func (s *Sprite) RenderSegmented(target d2interface.Surface, segmentsX, segments
 		for x := 0; x < segmentsX; x++ {
 			idx := x + y*segmentsX + frameOffset*segmentsX*segmentsY
 			if err := s.animation.SetCurrentFrame(idx); err != nil {
-				s.Error("SetCurrentFrame error" + err.Error())
+				s.Errorf("Error while setting frame (%d): %s", idx, err)
 			}
 
 			target.PushTranslation(s.x+currentX, s.y+currentY)

--- a/d2game/d2gamescreen/character_select.go
+++ b/d2game/d2gamescreen/character_select.go
@@ -1,7 +1,6 @@
 package d2gamescreen
 
 import (
-	"image/color"
 	"math"
 	"os"
 	"strconv"
@@ -190,7 +189,7 @@ func (v *CharacterSelect) OnLoad(loading d2screen.LoadingState) {
 
 		v.characterNameLabel[i] = v.uiManager.NewLabel(d2resource.Font16, d2resource.PaletteUnits)
 		v.characterNameLabel[i].SetPosition(offsetX, offsetY)
-		v.characterNameLabel[i].Color[0] = rgbaColor(lightBrown)
+		v.characterNameLabel[i].Color[0] = d2util.Color(lightBrown)
 
 		offsetY += labelHeight
 
@@ -201,7 +200,7 @@ func (v *CharacterSelect) OnLoad(loading d2screen.LoadingState) {
 
 		v.characterExpLabel[i] = v.uiManager.NewLabel(d2resource.Font16, d2resource.PaletteStatic)
 		v.characterExpLabel[i].SetPosition(offsetX, offsetY)
-		v.characterExpLabel[i].Color[0] = rgbaColor(lightGreen)
+		v.characterExpLabel[i].Color[0] = d2util.Color(lightGreen)
 	}
 
 	v.refreshGameStates()
@@ -265,31 +264,6 @@ func (v *CharacterSelect) loadCharScrollbar() {
 	scrollBarX, scrollBarY, scrollBarHeight := 586, 87, 369
 	v.charScrollbar = v.uiManager.NewScrollbar(scrollBarX, scrollBarY, scrollBarHeight)
 	v.charScrollbar.OnActivated(func() { v.onScrollUpdate() })
-}
-
-func rgbaColor(rgba uint32) color.RGBA {
-	result := color.RGBA{}
-	a, b, g, r := 0, 1, 2, 3
-	byteWidth := 8
-	byteMask := 0xff
-
-	for idx := 0; idx < 4; idx++ {
-		shift := idx * byteWidth
-		component := uint8(rgba>>shift) & uint8(byteMask)
-
-		switch idx {
-		case a:
-			result.A = component
-		case b:
-			result.B = component
-		case g:
-			result.G = component
-		case r:
-			result.R = component
-		}
-	}
-
-	return result
 }
 
 func (v *CharacterSelect) createButtons(loading d2screen.LoadingState) {
@@ -411,7 +385,7 @@ func (v *CharacterSelect) Render(screen d2interface.Surface) {
 	}
 
 	if v.showDeleteConfirmation {
-		screen.DrawRect(screenWidth, screenHeight, rgbaColor(blackHalfOpacity))
+		screen.DrawRect(screenWidth, screenHeight, d2util.Color(blackHalfOpacity))
 		v.okCancelBox.RenderSegmented(screen, 2, 1, 0)
 		v.deleteCharConfirmLabel.Render(screen)
 	}

--- a/d2game/d2gamescreen/cinematics.go
+++ b/d2game/d2gamescreen/cinematics.go
@@ -98,7 +98,7 @@ func (v *Cinematics) OnLoad(_ d2screen.LoadingState) {
 	v.cinematicsLabel = v.uiManager.NewLabel(d2resource.Font30, d2resource.PaletteStatic)
 	v.cinematicsLabel.Alignment = d2ui.HorizontalAlignCenter
 	v.cinematicsLabel.SetText(v.asset.TranslateLabel(d2enum.SelectCinematicLabel))
-	v.cinematicsLabel.Color[0] = rgbaColor(lightBrown)
+	v.cinematicsLabel.Color[0] = d2util.Color(lightBrown)
 	v.cinematicsLabel.SetPosition(cinematicsLabelX, cinematicsLabelY)
 }
 

--- a/d2game/d2gamescreen/main_menu.go
+++ b/d2game/d2gamescreen/main_menu.go
@@ -239,32 +239,32 @@ func (v *MainMenu) createLabels(loading d2screen.LoadingState) {
 	v.versionLabel = v.uiManager.NewLabel(d2resource.FontFormal12, d2resource.PaletteStatic)
 	v.versionLabel.Alignment = d2ui.HorizontalAlignRight
 	v.versionLabel.SetText("OpenDiablo2 - " + v.buildInfo.Branch)
-	v.versionLabel.Color[0] = rgbaColor(white)
+	v.versionLabel.Color[0] = d2util.Color(white)
 	v.versionLabel.SetPosition(versionLabelX, versionLabelY)
 
 	v.commitLabel = v.uiManager.NewLabel(d2resource.FontFormal10, d2resource.PaletteStatic)
 	v.commitLabel.Alignment = d2ui.HorizontalAlignLeft
 	v.commitLabel.SetText(v.buildInfo.Commit)
-	v.commitLabel.Color[0] = rgbaColor(white)
+	v.commitLabel.Color[0] = d2util.Color(white)
 	v.commitLabel.SetPosition(commitLabelX, commitLabelY)
 
 	v.copyrightLabel = v.uiManager.NewLabel(d2resource.FontFormal12, d2resource.PaletteStatic)
 	v.copyrightLabel.Alignment = d2ui.HorizontalAlignCenter
 	v.copyrightLabel.SetText(v.asset.TranslateLabel(d2enum.CopyrightLabel))
-	v.copyrightLabel.Color[0] = rgbaColor(lightBrown)
+	v.copyrightLabel.Color[0] = d2util.Color(lightBrown)
 	v.copyrightLabel.SetPosition(copyrightX, copyrightY)
 	loading.Progress(thirtyPercent)
 
 	v.copyrightLabel2 = v.uiManager.NewLabel(d2resource.FontFormal12, d2resource.PaletteStatic)
 	v.copyrightLabel2.Alignment = d2ui.HorizontalAlignCenter
 	v.copyrightLabel2.SetText(v.asset.TranslateLabel(d2enum.AllRightsReservedLabel))
-	v.copyrightLabel2.Color[0] = rgbaColor(lightBrown)
+	v.copyrightLabel2.Color[0] = d2util.Color(lightBrown)
 	v.copyrightLabel2.SetPosition(copyright2X, copyright2Y)
 
 	v.openDiabloLabel = v.uiManager.NewLabel(d2resource.FontFormal10, d2resource.PaletteStatic)
 	v.openDiabloLabel.Alignment = d2ui.HorizontalAlignCenter
 	v.openDiabloLabel.SetText("OpenDiablo2 is neither developed by, nor endorsed by Blizzard or its parent company Activision")
-	v.openDiabloLabel.Color[0] = rgbaColor(lightYellow)
+	v.openDiabloLabel.Color[0] = d2util.Color(lightYellow)
 	v.openDiabloLabel.SetPosition(od2LabelX, od2LabelY)
 	loading.Progress(fiftyPercent)
 
@@ -276,19 +276,19 @@ func (v *MainMenu) createLabels(loading d2screen.LoadingState) {
 	v.tcpJoinGameLabel = v.uiManager.NewLabel(d2resource.Font16, d2resource.PaletteUnits)
 	v.tcpJoinGameLabel.Alignment = d2ui.HorizontalAlignCenter
 	v.tcpJoinGameLabel.SetText(strings.Join(d2util.SplitIntoLinesWithMaxWidth(v.asset.TranslateLabel(d2enum.TCPIPEnterHostIPLabel), 27), "\n"))
-	v.tcpJoinGameLabel.Color[0] = rgbaColor(gold)
+	v.tcpJoinGameLabel.Color[0] = d2util.Color(gold)
 	v.tcpJoinGameLabel.SetPosition(joinGameX, joinGameY)
 
 	v.machineIP = v.uiManager.NewLabel(d2resource.Font24, d2resource.PaletteUnits)
 	v.machineIP.Alignment = d2ui.HorizontalAlignCenter
 	v.machineIP.SetText(v.asset.TranslateLabel(d2enum.TCPIPYourIPLabel) + "\n" + v.getLocalIP())
-	v.machineIP.Color[0] = rgbaColor(lightYellow)
+	v.machineIP.Color[0] = d2util.Color(lightYellow)
 	v.machineIP.SetPosition(machineIPX, machineIPY)
 
 	if v.errorLabel != nil {
 		v.errorLabel.SetPosition(errorLabelX, errorLabelY)
 		v.errorLabel.Alignment = d2ui.HorizontalAlignCenter
-		v.errorLabel.Color[0] = rgbaColor(red)
+		v.errorLabel.Color[0] = d2util.Color(red)
 	}
 }
 

--- a/d2game/d2player/key_binding_menu.go
+++ b/d2game/d2player/key_binding_menu.go
@@ -666,7 +666,7 @@ func (menu *KeyBindingMenu) onDefaultClicked() error {
 func (menu *KeyBindingMenu) onAcceptClicked() error {
 	for gameEvent, change := range menu.changesToBeSaved {
 		menu.keyMap.SetPrimaryBinding(gameEvent, change.primary)
-		menu.keyMap.SetSecondaryBinding(gameEvent, change.primary)
+		menu.keyMap.SetSecondaryBinding(gameEvent, change.secondary)
 	}
 
 	menu.changesToBeSaved = make(map[d2enum.GameEvent]*bindingChange)

--- a/d2game/d2player/quest_log.go
+++ b/d2game/d2player/quest_log.go
@@ -2,7 +2,6 @@ package d2player
 
 import (
 	"fmt"
-	"image/color"
 	"strings"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
@@ -216,13 +215,13 @@ func (s *QuestLog) Load() {
 
 	s.questName = s.uiManager.NewLabel(d2resource.Font16, d2resource.PaletteStatic)
 	s.questName.Alignment = d2ui.HorizontalAlignCenter
-	s.questName.Color[0] = rgbaColor(white)
+	s.questName.Color[0] = d2util.Color(white)
 	s.questName.SetPosition(questNameLabelX, questNameLabelY)
 	s.panelGroup.AddWidget(s.questName)
 
 	s.questDescr = s.uiManager.NewLabel(d2resource.Font16, d2resource.PaletteStatic)
 	s.questDescr.Alignment = d2ui.HorizontalAlignLeft
-	s.questDescr.Color[0] = rgbaColor(white)
+	s.questDescr.Color[0] = d2util.Color(white)
 	s.questDescr.SetPosition(questDescrLabelX, questDescrLabelY)
 	s.panelGroup.AddWidget(s.questDescr)
 
@@ -298,6 +297,8 @@ func (s *QuestLog) loadQuestIconsForAct(act int) *d2ui.WidgetGroup {
 
 		button := s.uiManager.NewButton(d2ui.ButtonTypeBlankQuestBtn, "")
 		button.SetPosition(x+questOffsetX, y+questOffsetY)
+		cw := n
+		button.SetEnabled(!(s.questStatus[s.cordsToQuestID(act, cw)] == d2enum.QuestStatusNotStarted))
 		buttons = append(buttons, button)
 
 		icon, err = s.makeQuestIconForAct(act, n)
@@ -383,7 +384,7 @@ func (s *QuestLog) setQuestLabel() {
 
 	s.questName.SetText(s.asset.TranslateString(fmt.Sprintf("qstsa%dq%d", s.selectedTab+1, s.selectedQuest)))
 
-	status := s.questStatus[s.cordsToQuestID(s.selectedTab+1, s.selectedQuest)]
+	status := s.questStatus[s.cordsToQuestID(s.selectedTab+1, s.selectedQuest)-1]
 	switch status {
 	case d2enum.QuestStatusCompleted:
 		s.questDescr.SetText(
@@ -393,6 +394,8 @@ func (s *QuestLog) setQuestLabel() {
 					questDescriptionLenght),
 				"\n"),
 		)
+	case d2enum.QuestStatusCompleting:
+		s.questDescr.SetText("")
 	case d2enum.QuestStatusNotStarted:
 		s.questDescr.SetText("")
 	default:
@@ -525,32 +528,6 @@ func (s *QuestLog) renderStaticPanelFrames(target d2interface.Surface) {
 
 		s.panel.Render(target)
 	}
-}
-
-// copy from character select (github.com/OpenDiablo2/OpenDiablo2/d2game/d2gamescreen/character_select.go)
-func rgbaColor(rgba uint32) color.RGBA {
-	result := color.RGBA{}
-	a, b, g, r := 0, 1, 2, 3
-	byteWidth := 8
-	byteMask := 0xff
-
-	for idx := 0; idx < 4; idx++ {
-		shift := idx * byteWidth
-		component := uint8(rgba>>shift) & uint8(byteMask)
-
-		switch idx {
-		case a:
-			result.A = component
-		case b:
-			result.B = component
-		case g:
-			result.G = component
-		case r:
-			result.R = component
-		}
-	}
-
-	return result
 }
 
 func (s *QuestLog) cordsToQuestID(act, number int) int {

--- a/d2game/d2player/quest_log.go
+++ b/d2game/d2player/quest_log.go
@@ -285,6 +285,7 @@ func (s *QuestLog) loadQuestIconsForAct(act int) *d2ui.WidgetGroup {
 	var icon *d2ui.Sprite
 
 	for n := 0; n < questsInAct; n++ {
+		cw := n
 		x, y := s.getPositionForSocket(n)
 
 		socket, err := s.uiManager.NewSprite(d2resource.QuestLogSocket, d2resource.PaletteSky)
@@ -297,8 +298,7 @@ func (s *QuestLog) loadQuestIconsForAct(act int) *d2ui.WidgetGroup {
 
 		button := s.uiManager.NewButton(d2ui.ButtonTypeBlankQuestBtn, "")
 		button.SetPosition(x+questOffsetX, y+questOffsetY)
-		cw := n
-		button.SetEnabled(!(s.questStatus[s.cordsToQuestID(act, cw)] == d2enum.QuestStatusNotStarted))
+		button.SetEnabled(s.questStatus[s.cordsToQuestID(act, cw)] != d2enum.QuestStatusNotStarted)
 		buttons = append(buttons, button)
 
 		icon, err = s.makeQuestIconForAct(act, n)


### PR DESCRIPTION
Hi there,
that's generally code clean up, so:
- removed not needed functions translating colors (rgbaColor) as we have global function in d2util (d2util.Color)
- now we can use SetEnabled on buttons, with HasImage=false (implemented in quest_log.go)
- updated d2term.OutputRaw (it use d2util.SplitIntoLinesWithMaxWidth)
- output printing in d2term now ignore log prefix
- fixed unexpected "configure controls" behavior, when primary key was saved as secondary