### PR TITLE
Quest Log - quest completion animation

### DIFF
--- a/d2common/d2resource/resource_paths.go
+++ b/d2common/d2resource/resource_paths.go
@@ -193,6 +193,7 @@ const (
 	QuestLogQDescrBtn       = "/data/global/ui/MENU/questlast.dc6"
 	QuestLogSocket          = "/data/global/ui/MENU/questsockets.dc6"
 	QuestLogAQuestAnimation = "/data/global/ui/MENU/a%dq%d.dc6"
+	QuestLogDoneSfx         = "cursor/questdone.wav"
 
 	// --- Mouse Pointers ---
 

--- a/d2game/d2gamescreen/game.go
+++ b/d2game/d2gamescreen/game.go
@@ -304,7 +304,8 @@ func (v *Game) bindGameControls() error {
 
 		var err error
 		v.gameControls, err = d2player.NewGameControls(v.asset, v.renderer, player, v.gameClient.MapEngine,
-			v.escapeMenu, v.mapRenderer, v, v.terminal, v.uiManager, v.keyMap, v.logLevel, v.gameClient.IsSinglePlayer())
+			v.escapeMenu, v.mapRenderer, v, v.terminal, v.uiManager, v.keyMap, v.audioProvider, v.logLevel,
+			v.gameClient.IsSinglePlayer())
 
 		if err != nil {
 			return err

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -124,6 +124,7 @@ func NewGameControls(
 	term d2interface.Terminal,
 	ui *d2ui.UIManager,
 	keyMap *KeyMap,
+	audioProvider d2interface.AudioProvider,
 	l d2util.LogLevel,
 	isSinglePlayer bool,
 ) (*GameControls, error) {
@@ -207,7 +208,7 @@ func NewGameControls(
 	inventoryRecord := asset.Records.Layout.Inventory[inventoryRecordKey]
 
 	heroStatsPanel := NewHeroStatsPanel(asset, ui, hero.Name(), hero.Class, l, hero.Stats)
-	questLog := NewQuestLog(asset, ui, l, hero.Act)
+	questLog := NewQuestLog(asset, ui, l, audioProvider, hero.Act)
 
 	inventory, err := NewInventory(asset, ui, l, hero.Gold, inventoryRecord)
 	if err != nil {
@@ -728,6 +729,7 @@ func (g *GameControls) Advance(elapsed float64) error {
 	g.mapRenderer.Advance(elapsed)
 	g.hud.Advance(elapsed)
 	g.inventory.Advance(elapsed)
+	g.questLog.Advance(elapsed)
 
 	if err := g.escapeMenu.Advance(elapsed); err != nil {
 		return err


### PR DESCRIPTION
Hi there,
Here is a list of major changes in this PR:
- when quest status = quest completing status quest completion animation is played
- fixed bug, when after switching to another tab, and getting back to previous we still was able to see highlighted socket
- fixed bug, when incorrect status value was passed to setQuestLabel, description was set to "qstsaXqX"
- added code descriptions
- removed still unused function questIDToCords