### PR TITLE
skill select menu dependencies

### DIFF
--- a/d2common/d2resource/languages_map.go
+++ b/d2common/d2resource/languages_map.go
@@ -62,7 +62,7 @@ key  | value         key  |  value
 So, GetLabelModifier returns value of offset in locale languages table
 */
 // some of values need to be set up. For now values with "checked" comment
-// was tested and works fine in main menu.
+// was tested and works fine.
 func GetLabelModifier(language string) int {
 	modifiers := map[string]int{
 		"ENG": 0, // (English) // checked

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -633,6 +633,8 @@ func (g *GameControls) OnMouseButtonDown(event d2interface.MouseEvent) bool {
 
 func (g *GameControls) toggleHeroStatsPanel() {
 	if !g.HelpOverlay.IsOpen() {
+		g.hud.skillSelectMenu.LeftPanel.Close()
+		g.hud.skillSelectMenu.RightPanel.Close()
 		g.questLog.Close()
 		g.heroStatsPanel.Toggle()
 		g.hud.miniPanel.SetMovedRight(g.heroStatsPanel.IsOpen())
@@ -645,9 +647,31 @@ func (g *GameControls) onCloseHeroStatsPanel() {
 	g.updateLayout()
 }
 
+func (g *GameControls) toggleLeftSkillPanel() {
+	if !g.HelpOverlay.IsOpen() {
+		g.inventory.Close()
+		g.skilltree.Close()
+		g.questLog.Close()
+		g.heroStatsPanel.Close()
+		g.hud.skillSelectMenu.ToggleLeftPanel()
+	}
+}
+
+func (g *GameControls) toggleRightSkillPanel() {
+	if !g.HelpOverlay.IsOpen() {
+		g.inventory.Close()
+		g.skilltree.Close()
+		g.questLog.Close()
+		g.heroStatsPanel.Close()
+		g.hud.skillSelectMenu.ToggleRightPanel()
+	}
+}
+
 func (g *GameControls) toggleQuestLog() {
 	if !g.HelpOverlay.IsOpen() {
 		g.heroStatsPanel.Close()
+		g.hud.skillSelectMenu.LeftPanel.Close()
+		g.hud.skillSelectMenu.RightPanel.Close()
 		g.questLog.Toggle()
 		g.hud.miniPanel.SetMovedRight(g.questLog.IsOpen())
 		g.updateLayout()
@@ -662,6 +686,8 @@ func (g *GameControls) onCloseQuestLog() {
 func (g *GameControls) toggleHelpOverlay() {
 	if !g.inventory.IsOpen() && !g.skilltree.IsOpen() && !g.heroStatsPanel.IsOpen() && !g.questLog.IsOpen() {
 		g.HelpOverlay.updateKeyMap(g.keyMap)
+		g.hud.skillSelectMenu.LeftPanel.Close()
+		g.hud.skillSelectMenu.RightPanel.Close()
 		g.hud.miniPanel.openDisabled()
 		g.HelpOverlay.Toggle()
 		g.updateLayout()
@@ -670,6 +696,8 @@ func (g *GameControls) toggleHelpOverlay() {
 
 func (g *GameControls) toggleInventoryPanel() {
 	if !g.HelpOverlay.IsOpen() {
+		g.hud.skillSelectMenu.LeftPanel.Close()
+		g.hud.skillSelectMenu.RightPanel.Close()
 		g.skilltree.Close()
 		g.inventory.Toggle()
 		g.hud.miniPanel.SetMovedLeft(g.inventory.IsOpen())
@@ -685,6 +713,8 @@ func (g *GameControls) onCloseInventory() {
 func (g *GameControls) toggleSkilltreePanel() {
 	if !g.HelpOverlay.IsOpen() {
 		g.inventory.Close()
+		g.hud.skillSelectMenu.LeftPanel.Close()
+		g.hud.skillSelectMenu.RightPanel.Close()
 		g.skilltree.Toggle()
 		g.hud.miniPanel.SetMovedLeft(g.skilltree.IsOpen())
 		g.updateLayout()
@@ -888,7 +918,7 @@ func (g *GameControls) onHoverActionable(item actionableType) {
 func (g *GameControls) onClickActionable(item actionableType) {
 	actionMap := map[actionableType]func(){
 		leftSkill: func() {
-			g.hud.skillSelectMenu.ToggleLeftPanel()
+			g.toggleLeftSkillPanel()
 		},
 
 		newStats: func() {
@@ -912,7 +942,7 @@ func (g *GameControls) onClickActionable(item actionableType) {
 		},
 
 		rightSkill: func() {
-			g.hud.skillSelectMenu.ToggleRightPanel()
+			g.toggleRightSkillPanel()
 		},
 
 		hpGlobe: func() {


### PR DESCRIPTION
Hi there,
I'm adding several dependencies for skillselect panels.
In retail d2, if we open any of skill panels and then, we open any of game panels (e. g. inventory) the skillselect menu is closed.
And conversely, if we open inventory panel, and then skill select menu, inventory is closed.