### PR TITLE
removed unused fields from d2player.GameControl.actionableRegions

### DIFF
--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -37,11 +37,8 @@ const mouseBtnActionsThreshold = 0.25
 const (
 	// Since they require special handling, not considering (1) globes, (2) content of the mini panel, (3) belt
 	leftSkill actionableType = iota
-	newStats
 	xp
-	walkRun
 	stamina
-	newSkills
 	rightSkill
 	hpGlobe
 	manaGlobe
@@ -53,30 +50,15 @@ const (
 	leftSkillWidth,
 	leftSkillHeight = 117, 550, 50, 50
 
-	newStatsX,
-	newStatsY,
-	newStatsWidth,
-	newStatsHeight = 206, 563, 30, 30
-
 	xpX,
 	xpY,
 	xpWidth,
 	xpHeight = 253, 560, 125, 5
 
-	walkRunX,
-	walkRunY,
-	walkRunWidth,
-	walkRunHeight = 255, 573, 17, 20
-
 	staminaX,
 	staminaY,
 	staminaWidth,
 	staminaHeight = 273, 573, 105, 20
-
-	newSkillsX,
-	newSkillsY,
-	newSkillsWidth,
-	newSkillsHeight = 562, 563, 30, 30
 
 	rightSkillX,
 	rightSkillY,
@@ -156,35 +138,17 @@ func NewGameControls(
 			Width:  leftSkillWidth,
 			Height: leftSkillHeight,
 		}},
-		{newStats, d2geom.Rectangle{
-			Left:   newStatsX,
-			Top:    newStatsY,
-			Width:  newStatsWidth,
-			Height: newStatsHeight,
-		}},
 		{xp, d2geom.Rectangle{
 			Left:   xpX,
 			Top:    xpY,
 			Width:  xpWidth,
 			Height: xpHeight,
 		}},
-		{walkRun, d2geom.Rectangle{
-			Left:   walkRunX,
-			Top:    walkRunY,
-			Width:  walkRunWidth,
-			Height: walkRunHeight,
-		}},
 		{stamina, d2geom.Rectangle{
 			Left:   staminaX,
 			Top:    staminaY,
 			Width:  staminaWidth,
 			Height: staminaHeight,
-		}},
-		{newSkills, d2geom.Rectangle{
-			Left:   newSkillsX,
-			Top:    newSkillsY,
-			Width:  newSkillsWidth,
-			Height: newSkillsHeight,
 		}},
 		{rightSkill, d2geom.Rectangle{
 			Left:   rightSkillX,
@@ -857,11 +821,8 @@ func (g *GameControls) ToggleManaStats() {
 func (g *GameControls) onHoverActionable(item actionableType) {
 	hoverMap := map[actionableType]func(){
 		leftSkill:  func() {},
-		newStats:   func() {},
 		xp:         func() {},
-		walkRun:    func() {},
 		stamina:    func() {},
-		newSkills:  func() {},
 		rightSkill: func() {},
 		hpGlobe:    func() {},
 		manaGlobe:  func() {},
@@ -883,24 +844,12 @@ func (g *GameControls) onClickActionable(item actionableType) {
 			g.toggleLeftSkillPanel()
 		},
 
-		newStats: func() {
-			g.Info("New Stats Selector Action Pressed")
-		},
-
 		xp: func() {
 			g.Info("XP Action Pressed")
 		},
 
-		walkRun: func() {
-			g.Info("Walk/Run Action Pressed")
-		},
-
 		stamina: func() {
 			g.Info("Stamina Action Pressed")
-		},
-
-		newSkills: func() {
-			g.Info("New Skills Selector Action Pressed")
 		},
 
 		rightSkill: func() {

--- a/d2game/d2player/hud.go
+++ b/d2game/d2player/hud.go
@@ -258,7 +258,6 @@ func (h *HUD) loadCustomWidgets() {
 }
 
 func (h *HUD) loadSkillResources() {
-	// https://github.com/OpenDiablo2/OpenDiablo2/issues/799
 	genericSkillsSprite, err := h.uiManager.NewSprite(d2resource.GenericSkills, d2resource.PaletteSky)
 	if err != nil {
 		h.Error(err.Error())
@@ -313,21 +312,6 @@ func (h *HUD) loadTooltips() {
 	labelY := staminaExperienceY - halfLabelHeight
 	h.staminaTooltip.SetPosition(labelX, labelY)
 
-	// runwalk tooltip
-	h.runWalkTooltip = h.uiManager.NewTooltip(d2resource.Font16, d2resource.PaletteSky, d2ui.TooltipXCenter, d2ui.TooltipYBottom)
-	rect = &h.actionableRegions[walkRun].rect
-
-	halfButtonWidth = rect.Width >> 1
-	halfButtonHeight := rect.Height >> 1
-
-	centerX = rect.Left + halfButtonWidth
-	centerY := rect.Top + halfButtonHeight
-
-	_, labelHeight = h.runWalkTooltip.GetSize()
-	labelX = centerX
-	labelY = centerY - halfButtonHeight - labelHeight
-	h.runWalkTooltip.SetPosition(labelX, labelY)
-
 	// experience tooltip
 	h.experienceTooltip = h.uiManager.NewTooltip(d2resource.Font16, d2resource.PaletteSky, d2ui.TooltipXCenter, d2ui.TooltipYTop)
 	rect = &h.actionableRegions[stamina].rect
@@ -348,8 +332,21 @@ func (h *HUD) loadUIButtons() {
 	h.runButton = h.uiManager.NewButton(d2ui.ButtonTypeRun, "")
 	h.runButton.SetPosition(runButtonX, runButtonY)
 	h.runButton.OnActivated(func() { h.onToggleRunButton(false) })
-	h.runButton.SetTooltip(h.runWalkTooltip)
+
+	h.runWalkTooltip = h.uiManager.NewTooltip(d2resource.Font16, d2resource.PaletteSky, d2ui.TooltipXCenter, d2ui.TooltipYTop)
+	// we must set text first, and then we're getting its height
 	h.updateRunTooltipText()
+
+	bw, bh := h.runButton.GetSize()
+	_, lh := h.runWalkTooltip.GetSize()
+	// nolint:gomnd // dividing by 2 (const)
+	labelX := runButtonX + bw/2
+	// nolint:gomnd // dividing by 2 (const)
+	labelY := runButtonY - bh/2 - lh/2
+
+	h.runWalkTooltip.SetPosition(labelX, labelY)
+	h.runButton.SetTooltip(h.runWalkTooltip)
+
 	h.panelGroup.AddWidget(h.runButton)
 
 	if h.hero.IsRunToggled() {


### PR DESCRIPTION
Hi there
I've removed unused and unnecesery fields from `d2player.GameControl.actionableRegions` (like `newSkills`, `newStats`)
I've also a bit changed way how runWalkButton's tooltip is created (now it use button's width/height instead of rectangle width/height)