### PR TITLE
fixed bug with terminal's logLevel

### DIFF
--- a/d2core/d2term/terminal_logger.go
+++ b/d2core/d2term/terminal_logger.go
@@ -33,7 +33,7 @@ func (tl *terminalLogger) Write(p []byte) (int, error) {
 	case strings.Index(lineLower, "error") > 0:
 		tl.terminal.Errorf(line)
 	case strings.Index(lineLower, "warning") > 0:
-		tl.terminal.Errorf(line)
+		tl.terminal.Warningf(line)
 	default:
 		tl.terminal.Printf(line)
 	}


### PR DESCRIPTION
Hi there,
I've fixed bug in terminal, when LogLevelWarning was printed as LogLevelError