### PR TITLE
Fix viewport and minipanel positions when closing panels via UI button

### DIFF
--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -621,6 +621,7 @@ func (g *GameControls) togglePartyPanel() {
 }
 
 func (g *GameControls) onCloseHeroStatsPanel() {
+	g.updateLayout()
 }
 
 func (g *GameControls) toggleLeftSkillPanel() {
@@ -642,6 +643,7 @@ func (g *GameControls) toggleQuestLog() {
 }
 
 func (g *GameControls) onCloseQuestLog() {
+	g.updateLayout()
 }
 
 func (g *GameControls) toggleHelpOverlay() {
@@ -659,6 +661,7 @@ func (g *GameControls) toggleInventoryPanel() {
 }
 
 func (g *GameControls) onCloseInventory() {
+	g.updateLayout()
 }
 
 func (g *GameControls) toggleSkilltreePanel() {
@@ -666,6 +669,7 @@ func (g *GameControls) toggleSkilltreePanel() {
 }
 
 func (g *GameControls) onCloseSkilltree() {
+	g.updateLayout()
 }
 
 func (g *GameControls) openEscMenu() {

--- a/d2game/d2player/game_controls.go
+++ b/d2game/d2player/game_controls.go
@@ -565,7 +565,6 @@ func (g *GameControls) clearLeftScreenSide() {
 	g.PartyPanel.Close()
 	g.questLog.Close()
 	g.hud.skillSelectMenu.ClosePanels()
-	g.hud.miniPanel.SetMovedRight(false)
 	g.updateLayout()
 }
 
@@ -573,7 +572,6 @@ func (g *GameControls) clearRightScreenSide() {
 	g.inventory.Close()
 	g.skilltree.Close()
 	g.hud.skillSelectMenu.ClosePanels()
-	g.hud.miniPanel.SetMovedLeft(false)
 	g.updateLayout()
 }
 
@@ -592,7 +590,6 @@ func (g *GameControls) openLeftPanel(panel Panel) {
 
 		if !isOpen {
 			panel.Open()
-			g.hud.miniPanel.SetMovedRight(true)
 			g.updateLayout()
 		}
 	}
@@ -606,7 +603,6 @@ func (g *GameControls) openRightPanel(panel Panel) {
 
 		if !isOpen {
 			panel.Open()
-			g.hud.miniPanel.SetMovedLeft(true)
 			g.updateLayout()
 		}
 	}
@@ -728,10 +724,13 @@ func (g *GameControls) updateLayout() {
 
 	switch {
 	case isRightPanelOpen == isLeftPanelOpen:
+		g.hud.miniPanel.ResetPosition()
 		g.mapRenderer.ViewportDefault()
 	case isRightPanelOpen:
+		g.hud.miniPanel.SetMovedRight(true)
 		g.mapRenderer.ViewportToLeft()
 	case isLeftPanelOpen:
+		g.hud.miniPanel.SetMovedLeft(true)
 		g.mapRenderer.ViewportToRight()
 	}
 }

--- a/d2game/d2player/mini_panel.go
+++ b/d2game/d2player/mini_panel.go
@@ -331,6 +331,16 @@ func (m *miniPanel) SetMovedLeft(moveLeft bool) {
 	m.movedLeft = moveLeft
 }
 
+func (m *miniPanel) ResetPosition() {
+	if m.movedLeft {
+		m.undoMoveLeft()
+		m.movedLeft = false
+	} else if m.movedRight {
+		m.undoMoveRight()
+		m.movedRight = false
+	}
+}
+
 func (m *miniPanel) SetMovedRight(moveRight bool) {
 	if m.movedRight == moveRight {
 		return


### PR DESCRIPTION
The viewport and minipanel had wrong positions when you close a panel via its UI button (the bug doesn't happen when closing via keyboard buttons)

To fix this:
- Moved the minipanel positioning logic to updateLayout & created miniPanel.ResetPosition function
- Called updateLayout in every panel's onClose callback