### PR TITLE
Hotfix: Inventory display bugs

### DIFF
--- a/d2game/d2player/inventory.go
+++ b/d2game/d2player/inventory.go
@@ -251,7 +251,7 @@ func (g *Inventory) Render(target d2interface.Surface) {
 	g.renderFrame(target)
 
 	g.grid.Render(target)
-	g.renderItemHover(target)
+	g.showItemDescriptionTooltip()
 }
 
 func (g *Inventory) renderFrame(target d2interface.Surface) {
@@ -287,8 +287,26 @@ func (g *Inventory) renderFrame(target d2interface.Surface) {
 	}
 }
 
-func (g *Inventory) renderItemHover(target d2interface.Surface) {
+func (g *Inventory) showItemDescriptionTooltip() {
 	hovering := false
+
+	for _, slot := range g.grid.equipmentSlots {
+		mx, my := g.lastMouseX, g.lastMouseY
+		hovering = hovering || ((mx > slot.x) && (mx < slot.x+slot.width) && (my < slot.y) && (my > slot.y-slot.height))
+		if hovering {
+			if !g.hovering {
+				g.hoverX, g.hoverY = mx, my
+			}
+			g.showEquippedItemDescriptionTooltip(&slot)
+
+			break
+		}
+	}
+
+	g.hovering = hovering
+	if hovering {
+		return
+	}
 
 	for idx := range g.grid.items {
 		item := g.grid.items[idx]
@@ -304,22 +322,34 @@ func (g *Inventory) renderItemHover(target d2interface.Surface) {
 				g.hoverX, g.hoverY = mx, my
 			}
 
-			g.renderItemDescription(target, item)
+			g.showGridItemDescriptionTooltip(item)
 
 			break
 		}
 	}
 
 	g.hovering = hovering
+	if !g.hovering {
+		g.itemTooltip.SetVisible(false)
+	}
 }
 
-func (g *Inventory) renderItemDescription(target d2interface.Surface, i InventoryItem) {
+func (g *Inventory) showGridItemDescriptionTooltip(i InventoryItem) {
 	if !g.moveGoldPanel.IsOpen() {
 		lines := i.GetItemDescription()
 		g.itemTooltip.SetTextLines(lines)
 		_, y := g.grid.SlotToScreen(i.InventoryGridSlot())
 
 		g.itemTooltip.SetPosition(g.hoverX, y)
-		g.itemTooltip.Render(target)
+		g.itemTooltip.SetVisible(true)
+	}
+}
+
+func (g *Inventory) showEquippedItemDescriptionTooltip(slot *EquipmentSlot) {
+	if !g.moveGoldPanel.IsOpen() {
+		lines := slot.item.GetItemDescription()
+		g.itemTooltip.SetTextLines(lines)
+		g.itemTooltip.SetPosition(g.hoverX, slot.y)
+		g.itemTooltip.SetVisible(true)
 	}
 }


### PR DESCRIPTION
- No tooltips for equipped items
![image](https://user-images.githubusercontent.com/3226658/105578817-29e67480-5d83-11eb-9cdd-c1b12b31b6f7.png)

- Item tooltips are rendered before UI Frames, causing them to be cut
![image](https://user-images.githubusercontent.com/3226658/105578795-06bbc500-5d83-11eb-9db1-3a70b269e8c9.png) 