### PR TITLE
Minor refactor of d2cof

### DIFF
--- a/d2common/d2datautils/stream_reader.go
+++ b/d2common/d2datautils/stream_reader.go
@@ -107,6 +107,10 @@ func (v *StreamReader) Size() uint64 {
 
 // ReadBytes reads multiple bytes
 func (v *StreamReader) ReadBytes(count int) ([]byte, error) {
+	if count <= 0 {
+		return nil, nil
+	}
+
 	size := v.Size()
 	if v.position >= size || v.position+uint64(count) > size {
 		return nil, io.EOF

--- a/d2common/d2fileformats/d2cof/cof_test.go
+++ b/d2common/d2fileformats/d2cof/cof_test.go
@@ -1,0 +1,35 @@
+package d2cof
+
+import "testing"
+
+func TestCOF_New(t *testing.T) {
+	c := New()
+
+	if c == nil {
+		t.Error("method New created nil instance")
+	}
+}
+
+func TestCOF_Marshal_Unmarshal(t *testing.T) {
+	cof1 := New()
+	cof2 := New()
+
+	var err error
+
+	err = cof1.Unmarshal(make([]byte, 1000))
+	if err != nil {
+		t.Error(err)
+	}
+
+	cof1.Speed = 255
+	data1 := cof1.Marshal()
+
+	err = cof2.Unmarshal(data1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if cof2.Speed != cof1.Speed {
+		t.Error("marshaled data does not match unmarshaled data")
+	}
+}

--- a/d2core/d2asset/asset_manager.go
+++ b/d2core/d2asset/asset_manager.go
@@ -542,7 +542,7 @@ func (am *AssetManager) LoadCOF(cofPath string) (*d2cof.COF, error) {
 		return nil, err
 	}
 
-	cof, err := d2cof.Load(fileData)
+	cof, err := d2cof.Unmarshal(fileData)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Changed `Load` to `Unmarshal`
* made `Marshal` and `Unmarshal` into methods of `COF`
* added `New` function which creates a new, empty COF instance
* added helper functions `Marshal` and `Unmarshal` (separate from the COF methods, these are package-level functions)
* Changed `StreamReader.ReadBytes` to account for edge case of reading 0
bytes (this was returning an error when it should not have)
* added really simple unit tests for COF