### PR TITLE
Date encoder: font table

### DIFF
--- a/d2common/d2fileformats/d2font/doc.go
+++ b/d2common/d2fileformats/d2font/doc.go
@@ -1,0 +1,3 @@
+// Package d2font contains logic for loading and processing
+// d2 fonts
+package d2font

--- a/d2common/d2fileformats/d2font/font.go
+++ b/d2common/d2fileformats/d2font/font.go
@@ -1,7 +1,8 @@
-package d2asset
+package d2font
 
 import (
 	"encoding/binary"
+	"fmt"
 	"image/color"
 	"strings"
 
@@ -23,6 +24,23 @@ type Font struct {
 	color  color.Color
 }
 
+// Load loads a new font from byte slice
+func Load(data []byte, sheet d2interface.Animation) (*Font, error) {
+	if string(data[:5]) != "Woo!\x01" {
+		return nil, fmt.Errorf("invalid font table format")
+	}
+
+	font := &Font{
+		table: data,
+		sheet: sheet,
+		color: color.White,
+	}
+
+	font.initGlyphs()
+
+	return font, nil
+}
+
 // SetColor sets the fonts color
 func (f *Font) SetColor(c color.Color) {
 	f.color = c
@@ -30,9 +48,6 @@ func (f *Font) SetColor(c color.Color) {
 
 // GetTextMetrics returns the dimensions of the Font element in pixels
 func (f *Font) GetTextMetrics(text string) (width, height int) {
-	if f.glyphs == nil {
-		f.initGlyphs()
-	}
 
 	var (
 		lineWidth  int

--- a/d2common/d2fileformats/d2font/font.go
+++ b/d2common/d2fileformats/d2font/font.go
@@ -14,6 +14,14 @@ const (
 	knownSignature = "Woo!\x01"
 )
 
+const (
+	signatureBytesCount     = 5
+	unknownHeaderBytesCount = 7
+	unknown1BytesCount      = 1
+	unknown2BytesCount      = 4
+	unknown3BytesCount      = 4
+)
+
 type fontGlyph struct {
 	unknown1 []byte
 	unknown2 []byte
@@ -36,7 +44,7 @@ type Font struct {
 func Load(data []byte, sheet d2interface.Animation) (*Font, error) {
 	sr := d2datautils.CreateStreamReader(data)
 
-	signature, err := sr.ReadBytes(5)
+	signature, err := sr.ReadBytes(signatureBytesCount)
 	if err != nil {
 		return nil, err
 	}
@@ -51,12 +59,15 @@ func Load(data []byte, sheet d2interface.Animation) (*Font, error) {
 		color: color.White,
 	}
 
-	font.unknownHeaderBytes, err = sr.ReadBytes(7)
+	font.unknownHeaderBytes, err = sr.ReadBytes(unknownHeaderBytesCount)
 	if err != nil {
 		return nil, err
 	}
 
-	font.initGlyphs(sr)
+	err = font.initGlyphs(sr)
+	if err != nil {
+		return nil, err
+	}
 
 	return font, nil
 }
@@ -68,7 +79,6 @@ func (f *Font) SetColor(c color.Color) {
 
 // GetTextMetrics returns the dimensions of the Font element in pixels
 func (f *Font) GetTextMetrics(text string) (width, height int) {
-
 	var (
 		lineWidth  int
 		lineHeight int
@@ -144,7 +154,7 @@ func (f *Font) initGlyphs(sr *d2datautils.StreamReader) error {
 
 		var glyph fontGlyph
 
-		glyph.unknown1, err = sr.ReadBytes(1)
+		glyph.unknown1, err = sr.ReadBytes(unknown1BytesCount)
 		if err != nil {
 			return err
 		}
@@ -158,7 +168,7 @@ func (f *Font) initGlyphs(sr *d2datautils.StreamReader) error {
 
 		glyph.height = maxCharHeight
 
-		glyph.unknown2, err = sr.ReadBytes(4)
+		glyph.unknown2, err = sr.ReadBytes(unknown2BytesCount)
 		if err != nil {
 			return err
 		}
@@ -170,7 +180,7 @@ func (f *Font) initGlyphs(sr *d2datautils.StreamReader) error {
 
 		glyph.frame = int(frame)
 
-		glyph.unknown3, err = sr.ReadBytes(4)
+		glyph.unknown3, err = sr.ReadBytes(unknown3BytesCount)
 		if err != nil {
 			return err
 		}
@@ -183,6 +193,7 @@ func (f *Font) initGlyphs(sr *d2datautils.StreamReader) error {
 	return nil
 }
 
+// Marshal encodes font back into byte slice
 func (f *Font) Marshal() []byte {
 	sw := d2datautils.CreateStreamWriter()
 

--- a/d2core/d2asset/asset_manager.go
+++ b/d2core/d2asset/asset_manager.go
@@ -226,6 +226,8 @@ func (am *AssetManager) LoadFont(tablePath, spritePath, palettePath string) (*d2
 		return nil, err
 	}
 
+	am.Debugf(fmtLoadFont, tablePath, spritePath, palettePath)
+
 	font, err := d2font.Load(tableData, sheet)
 	if err != nil {
 		return nil, fmt.Errorf("error while loading font table %s: %v", tablePath, err)

--- a/d2core/d2asset/asset_manager.go
+++ b/d2core/d2asset/asset_manager.go
@@ -228,10 +228,12 @@ func (am *AssetManager) LoadFont(tablePath, spritePath, palettePath string) (*d2
 
 	am.Debugf(fmtLoadFont, tablePath, spritePath, palettePath)
 
-	font, err := d2font.Load(tableData, sheet)
+	font, err := d2font.Load(tableData)
 	if err != nil {
 		return nil, fmt.Errorf("error while loading font table %s: %v", tablePath, err)
 	}
+
+	font.SetBackground(sheet)
 
 	err = am.fonts.Insert(cachePath, font, defaultCacheEntryWeight)
 

--- a/d2core/d2gui/label.go
+++ b/d2core/d2gui/label.go
@@ -4,8 +4,8 @@ import (
 	"image/color"
 	"time"
 
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2font"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
 )
 
 // Constants defining the main shades of basic colors
@@ -25,7 +25,7 @@ type Label struct {
 
 	renderer    d2interface.Renderer
 	text        string
-	font        *d2asset.Font
+	font        *d2font.Font
 	surface     d2interface.Surface
 	color       color.RGBA
 	hoverColor  color.RGBA
@@ -35,7 +35,7 @@ type Label struct {
 	blinkTimer  time.Time
 }
 
-func createLabel(renderer d2interface.Renderer, text string, font *d2asset.Font, col color.RGBA) (*Label, error) {
+func createLabel(renderer d2interface.Renderer, text string, font *d2font.Font, col color.RGBA) (*Label, error) {
 	label := &Label{
 		font:       font,
 		renderer:   renderer,

--- a/d2core/d2gui/layout.go
+++ b/d2core/d2gui/layout.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"image/color"
 
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2font"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2math"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2util"
@@ -532,7 +533,7 @@ func (l *Layout) createButton(renderer d2interface.Renderer, text string,
 	return button, nil
 }
 
-func (l *Layout) loadFont(fontStyle FontStyle) (*d2asset.Font, error) {
+func (l *Layout) loadFont(fontStyle FontStyle) (*d2font.Font, error) {
 	config := getFontStyleConfig(fontStyle)
 	if config == nil {
 		return nil, errors.New("invalid font style")

--- a/d2core/d2ui/label.go
+++ b/d2core/d2ui/label.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/OpenDiablo2/OpenDiablo2/d2core/d2asset"
+	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2fileformats/d2font"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2interface"
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2util"
@@ -19,7 +19,7 @@ type Label struct {
 	*BaseWidget
 	text            string
 	Alignment       HorizontalAlign
-	font            *d2asset.Font
+	font            *d2font.Font
 	Color           map[int]color.Color
 	backgroundColor color.Color
 


### PR DESCRIPTION
Hi there
in this PR:
- moved font table manager into `d2fileformats`, so it  isn't part of AssetManager anymore
- added encoder to d2font
- rewritten d2font.Load to use StreamReader

this is also related with #909 and https://github.com/OpenDiablo2/HellSpawner/issues/85
over that, we'll be able to rewrite Hellspawner's font editor, to use OpenDiablo2's font table package