### PR TITLE
hotfix: removed unnecessary 0 in unknown3 bytes list

### DIFF
--- a/d2common/d2fileformats/d2font/d2fontglyph/font_glyph.go
+++ b/d2common/d2fileformats/d2font/d2fontglyph/font_glyph.go
@@ -8,7 +8,7 @@ func Create(frame, width, height int) *FontGlyph {
 	result := &FontGlyph{
 		unknown1: []byte{0},
 		unknown2: []byte{1, 0, 0},
-		unknown3: []byte{0, 0, 0, 0, 0},
+		unknown3: []byte{0, 0, 0, 0},
 		frame:    frame,
 		width:    width,
 		height:   height,


### PR DESCRIPTION
Hi there,
It broke encoder

test result:
![image](https://user-images.githubusercontent.com/73652197/108486115-ff161000-729d-11eb-8b61-c96de6f04f26.png)
