### PR TITLE
bugfix string table encoding

### DIFF
--- a/d2common/d2fileformats/d2tbl/text_dictionary.go
+++ b/d2common/d2fileformats/d2tbl/text_dictionary.go
@@ -185,7 +185,12 @@ func (td *TextDictionary) Marshal() []byte {
 
 	sw.PushUint16(0)
 
-	sw.PushInt32(int32(len(*td)))
+	keys := make([]string, 0)
+	for key := range *td {
+		keys = append(keys, key)
+	}
+
+	sw.PushInt32(int32(len(keys)))
 
 	// version (always 0)
 	sw.PushBytes(0)
@@ -205,7 +210,8 @@ func (td *TextDictionary) Marshal() []byte {
 	// dataPos is a position, when we're placing data stream
 	dataPos := len(sw.GetBytes()) + 17*len(*td)
 
-	for key, value := range *td {
+	for _, key := range keys {
+		value := (*td)[key]
 		// non-zero if record is used (for us, every record is used ;-)
 		sw.PushBytes(1)
 
@@ -227,7 +233,8 @@ func (td *TextDictionary) Marshal() []byte {
 	}
 
 	// data stream: put all data in appropriate order
-	for key, value := range *td {
+	for _, key := range keys {
+		value := (*td)[key]
 		for _, i := range key {
 			sw.PushBytes(byte(i))
 		}

--- a/d2common/d2fileformats/d2tbl/text_dictionary.go
+++ b/d2common/d2fileformats/d2tbl/text_dictionary.go
@@ -224,7 +224,13 @@ func (td *TextDictionary) Marshal() []byte {
 		sw.PushUint32(0)
 
 		sw.PushUint32(uint32(dataPos))
-		dataPos += len(key) + 1
+
+		if key[0] == '#' {
+			// 1 for X, and 1 for separator
+			dataPos += 2
+		} else {
+			dataPos += len(key) + 1
+		}
 
 		sw.PushUint32(uint32(dataPos))
 		dataPos += len(value) + 1
@@ -235,6 +241,10 @@ func (td *TextDictionary) Marshal() []byte {
 	// data stream: put all data in appropriate order
 	for _, key := range keys {
 		value := (*td)[key]
+
+		if key[0] == '#' {
+			key = "x"
+		}
 
 		for _, i := range key {
 			sw.PushBytes(byte(i))

--- a/d2common/d2fileformats/d2tbl/text_dictionary.go
+++ b/d2common/d2fileformats/d2tbl/text_dictionary.go
@@ -235,6 +235,7 @@ func (td *TextDictionary) Marshal() []byte {
 	// data stream: put all data in appropriate order
 	for _, key := range keys {
 		value := (*td)[key]
+
 		for _, i := range key {
 			sw.PushBytes(byte(i))
 		}

--- a/d2common/d2fileformats/d2tbl/text_dictionary_test.go
+++ b/d2common/d2fileformats/d2tbl/text_dictionary_test.go
@@ -8,7 +8,7 @@ func exampleData() *TextDictionary {
 	result := &TextDictionary{
 		"abc":        "def",
 		"someStr":    "Some long string",
-		"teststring": "TeSt",
+		"teststring": "TeStxwsas123 long strin122*8:wq",
 	}
 
 	return result
@@ -27,7 +27,7 @@ func TestTBL_Marshal(t *testing.T) {
 		newValue, ok := newTbl[key]
 
 		if !ok {
-			t.Fatal("string wasn't encoded to table")
+			t.Fatalf("string %s wasn't encoded to table", key)
 		}
 
 		if newValue != value {

--- a/d2common/d2fileformats/d2tbl/text_dictionary_test.go
+++ b/d2common/d2fileformats/d2tbl/text_dictionary_test.go
@@ -1,8 +1,6 @@
 package d2tbl
 
 import (
-	"fmt"
-
 	"testing"
 )
 
@@ -25,7 +23,30 @@ func TestTBL_Marshal(t *testing.T) {
 		t.Error(err)
 	}
 
-	fmt.Println(newTbl)
+	for key, value := range *tbl {
+		newValue, ok := newTbl[key]
+
+		if !ok {
+			t.Fatalf("string %s wasn't encoded to table", key)
+		}
+
+		if newValue != value {
+			t.Fatal("unexpected value set")
+		}
+	}
+}
+
+func TestTBL_MarshalNoNameString(t *testing.T) {
+	tbl := &TextDictionary{
+		"#0": "OKEY",
+	}
+
+	data := tbl.Marshal()
+
+	newTbl, err := LoadTextDictionary(data)
+	if err != nil {
+		t.Error(err)
+	}
 
 	for key, value := range *tbl {
 		newValue, ok := newTbl[key]

--- a/d2common/d2fileformats/d2tbl/text_dictionary_test.go
+++ b/d2common/d2fileformats/d2tbl/text_dictionary_test.go
@@ -6,8 +6,11 @@ import (
 
 func exampleData() *TextDictionary {
 	result := &TextDictionary{
-		"abc":        "def",
-		"someStr":    "Some long string",
+		"abc":     "def",
+		"someStr": "Some long string",
+		// #2 is non-named (X: OK)
+		// so 2 is an index in map
+		"#2":         "OK",
 		"teststring": "TeStxwsas123 long strin122*8:wq",
 	}
 

--- a/d2common/d2fileformats/d2tbl/text_dictionary_test.go
+++ b/d2common/d2fileformats/d2tbl/text_dictionary_test.go
@@ -1,16 +1,15 @@
 package d2tbl
 
 import (
+	"fmt"
+
 	"testing"
 )
 
 func exampleData() *TextDictionary {
 	result := &TextDictionary{
-		"abc":     "def",
-		"someStr": "Some long string",
-		// #2 is non-named (X: OK)
-		// so 2 is an index in map
-		"#2":         "OK",
+		"abc":        "def",
+		"someStr":    "Some long string",
 		"teststring": "TeStxwsas123 long strin122*8:wq",
 	}
 
@@ -25,6 +24,8 @@ func TestTBL_Marshal(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	fmt.Println(newTbl)
 
 	for key, value := range *tbl {
 		newValue, ok := newTbl[key]


### PR DESCRIPTION
I've used map ranges twice, and each loop ranged the map in another order, so text dictionary encoder sometimes didn't work