### PR TITLE
animation data: methods for edition animation data records count and animation entries

### DIFF
--- a/d2common/d2fileformats/d2animdata/animdata.go
+++ b/d2common/d2fileformats/d2animdata/animdata.go
@@ -92,6 +92,7 @@ func (ad *AnimationData) DeleteRecord(name string, recordIdx int) error {
 	return nil
 }
 
+// AddEntry adds a new animation entry with name given
 func (ad *AnimationData) AddEntry(name string) error {
 	_, found := ad.entries[name]
 	if found {
@@ -103,6 +104,7 @@ func (ad *AnimationData) AddEntry(name string) error {
 	return nil
 }
 
+// DeleteEntry deltees entry with specified name
 func (ad *AnimationData) DeleteEntry(name string) error {
 	_, found := ad.entries[name]
 	if !found {

--- a/d2common/d2fileformats/d2animdata/animdata.go
+++ b/d2common/d2fileformats/d2animdata/animdata.go
@@ -92,6 +92,28 @@ func (ad *AnimationData) DeleteRecord(name string, recordIdx int) error {
 	return nil
 }
 
+func (ad *AnimationData) AddEntry(name string) error {
+	_, found := ad.entries[name]
+	if found {
+		return fmt.Errorf("entry of name %s already exist", name)
+	}
+
+	ad.entries[name] = make([]*AnimationDataRecord, 0)
+
+	return nil
+}
+
+func (ad *AnimationData) DeleteEntry(name string) error {
+	_, found := ad.entries[name]
+	if !found {
+		return fmt.Errorf("entry named %s doesn't exist", name)
+	}
+
+	delete(ad.entries, name)
+
+	return nil
+}
+
 // Load loads the data into an AnimationData struct
 //nolint:gocognit,funlen // can't reduce
 func Load(data []byte) (*AnimationData, error) {

--- a/d2common/d2fileformats/d2animdata/animdata.go
+++ b/d2common/d2fileformats/d2animdata/animdata.go
@@ -61,6 +61,34 @@ func (ad *AnimationData) GetRecordsCount() int {
 	return len(ad.entries)
 }
 
+func (ad *AnimationData) PushRecord(name string) {
+	ad.entries[name] = append(
+		ad.entries[name],
+		&AnimationDataRecord{
+			name: name,
+		},
+	)
+}
+
+func (ad *AnimationData) DeleteRecord(name string, recordIdx int) error {
+	newRecords := make([]*AnimationDataRecord, 0)
+	for n, i := range ad.entries[name] {
+		if n == recordIdx {
+			continue
+		}
+
+		newRecords = append(newRecords, i)
+	}
+
+	if len(ad.entries[name]) == len(newRecords) {
+		return fmt.Errorf("index %d not found", recordIdx)
+	}
+
+	ad.entries[name] = newRecords
+
+	return nil
+}
+
 // Load loads the data into an AnimationData struct
 //nolint:gocognit,funlen // can't reduce
 func Load(data []byte) (*AnimationData, error) {

--- a/d2common/d2fileformats/d2animdata/animdata.go
+++ b/d2common/d2fileformats/d2animdata/animdata.go
@@ -61,6 +61,7 @@ func (ad *AnimationData) GetRecordsCount() int {
 	return len(ad.entries)
 }
 
+// PushRecord adds a new record to entry named 'name'
 func (ad *AnimationData) PushRecord(name string) {
 	ad.entries[name] = append(
 		ad.entries[name],
@@ -70,8 +71,10 @@ func (ad *AnimationData) PushRecord(name string) {
 	)
 }
 
+// DeleteRecord teletes specified index from specified entry
 func (ad *AnimationData) DeleteRecord(name string, recordIdx int) error {
 	newRecords := make([]*AnimationDataRecord, 0)
+
 	for n, i := range ad.entries[name] {
 		if n == recordIdx {
 			continue

--- a/d2common/d2fileformats/d2animdata/animdata_test.go
+++ b/d2common/d2fileformats/d2animdata/animdata_test.go
@@ -262,7 +262,10 @@ func TestAnimationData_AddEntry(t *testing.T) {
 		entries: make(map[string][]*AnimationDataRecord),
 	}
 
-	ad.AddEntry("a")
+	err := ad.AddEntry("a")
+	if err != nil {
+		t.Error(err)
+	}
 
 	if _, found := ad.entries["a"]; !found {
 		t.Fatal("entry wasn't added")
@@ -276,7 +279,10 @@ func TestAnimationData_DeleteEntry(t *testing.T) {
 		},
 	}
 
-	ad.DeleteEntry("a")
+	err := ad.DeleteEntry("a")
+	if err != nil {
+		t.Error(err)
+	}
 
 	if _, found := ad.entries["a"]; found {
 		t.Fatal("Entry wasn't deleted")

--- a/d2common/d2fileformats/d2animdata/animdata_test.go
+++ b/d2common/d2fileformats/d2animdata/animdata_test.go
@@ -256,3 +256,29 @@ func TestAnimationData_PushRecord(t *testing.T) {
 		t.Fatal("unexpected name of new record was set")
 	}
 }
+
+func TestAnimationData_AddEntry(t *testing.T) {
+	ad := &AnimationData{
+		entries: make(map[string][]*AnimationDataRecord),
+	}
+
+	ad.AddEntry("a")
+
+	if _, found := ad.entries["a"]; !found {
+		t.Fatal("entry wasn't added")
+	}
+}
+
+func TestAnimationData_DeleteEntry(t *testing.T) {
+	ad := &AnimationData{
+		entries: map[string][]*AnimationDataRecord{
+			"a": {{}, {}},
+		},
+	}
+
+	ad.DeleteEntry("a")
+
+	if _, found := ad.entries["a"]; found {
+		t.Fatal("Entry wasn't deleted")
+	}
+}

--- a/d2common/d2fileformats/d2animdata/animdata_test.go
+++ b/d2common/d2fileformats/d2animdata/animdata_test.go
@@ -155,7 +155,7 @@ func TestAnimationDataRecord_FPS(t *testing.T) {
 	}
 }
 
-func TestAnimationDataRecord_Marshal(t *testing.T) {
+func TestAnimationData_Marshal(t *testing.T) {
 	file, fileErr := os.Open("testdata/AnimData.d2")
 	if fileErr != nil {
 		t.Error("cannot open test data file")
@@ -207,5 +207,52 @@ func TestAnimationDataRecord_Marshal(t *testing.T) {
 				t.Fatal("unexpected record set")
 			}
 		}
+	}
+}
+
+func TestAnimationData_DeleteRecord(t *testing.T) {
+	ad := &AnimationData{
+		entries: map[string][]*AnimationDataRecord{
+			"a": {
+				{name: "a", speed: 1, framesPerDirection: 1},
+				{name: "a", speed: 2, framesPerDirection: 2},
+				{name: "a", speed: 3, framesPerDirection: 3},
+			},
+		},
+	}
+
+	err := ad.DeleteRecord("a", 1)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ad.entries["a"]) != 2 {
+		t.Fatal("Delete record error")
+	}
+
+	if ad.entries["a"][1].speed != 3 {
+		t.Fatal("Invalid index deleted")
+	}
+}
+
+func TestAnimationData_PushRecord(t *testing.T) {
+	ad := &AnimationData{
+		entries: map[string][]*AnimationDataRecord{
+			"a": {
+				{name: "a", speed: 1, framesPerDirection: 1},
+				{name: "a", speed: 2, framesPerDirection: 2},
+			},
+		},
+	}
+
+	ad.PushRecord("a")
+
+	if len(ad.entries["a"]) != 3 {
+		t.Fatal("No record was pushed")
+	}
+
+	if ad.entries["a"][2].name != "a" {
+		t.Fatal("unexpected name of new record was set")
 	}
 }


### PR DESCRIPTION
Hi there,
this PR contains:
- Push Record (adds a new record to specific entry
 - Delete Record (removes specified record from specified entry)
 - Add Entry (adds a new entry with specific name)
 - Delete Entry (removes specified entry)
- unit tests for these methods

necessary for OpenDiablo2/HellSpawner#78
and to complete OpenDiablo2/HellSpawner#219