### PR TITLE
d2pl2: added RGBA and SetRGBA methods 

### DIFF
--- a/d2common/d2fileformats/d2pl2/pl2_color.go
+++ b/d2common/d2fileformats/d2pl2/pl2_color.go
@@ -1,9 +1,46 @@
 package d2pl2
 
+const (
+	bitShift0 = 8 * iota
+	bitShift8
+	bitShift16
+	bitShift24
+)
+
 // PL2Color represents an RGBA color
 type PL2Color struct {
 	R uint8
 	G uint8
 	B uint8
 	_ uint8
+}
+
+const (
+	mask = 0xff
+)
+
+func (p *PL2Color) RGBA() uint32 {
+	return toComposite(p.R, p.G, p.B, mask)
+}
+
+func (p *PL2Color) SetRGBA(rgba uint32) {
+	p.R, p.G, p.B, _ = toComponent(rgba)
+}
+
+func toComposite(w, x, y, z uint8) uint32 {
+	composite := uint32(w) << bitShift24
+	composite += uint32(x) << bitShift16
+	composite += uint32(y) << bitShift8
+	composite += uint32(z) << bitShift0
+
+	return composite
+}
+
+func toComponent(wxyz uint32) (w, x, y, z uint8) {
+	w = uint8(wxyz >> bitShift24 & mask)
+	x = uint8(wxyz >> bitShift16 & mask)
+	y = uint8(wxyz >> bitShift8 & mask)
+	z = uint8(wxyz >> bitShift0 & mask)
+
+	return w, x, y, z
 }

--- a/d2common/d2fileformats/d2pl2/pl2_color.go
+++ b/d2common/d2fileformats/d2pl2/pl2_color.go
@@ -24,7 +24,7 @@ func (p *PL2Color) RGBA() uint32 {
 
 // SetRGBA sets PL2Color's value to rgba given
 func (p *PL2Color) SetRGBA(rgba uint32) {
-	p.R, p.G, p.B, _ = toComponent(rgba)
+	p.R, p.G, p.B = toComponent(rgba)
 }
 
 func toComposite(w, x, y, z uint8) uint32 {
@@ -36,11 +36,10 @@ func toComposite(w, x, y, z uint8) uint32 {
 	return composite
 }
 
-func toComponent(wxyz uint32) (w, x, y, z uint8) {
+func toComponent(wxyz uint32) (w, x, y uint8) {
 	w = uint8(wxyz >> bitShift24 & mask)
 	x = uint8(wxyz >> bitShift16 & mask)
 	y = uint8(wxyz >> bitShift8 & mask)
-	z = uint8(wxyz >> bitShift0 & mask)
 
-	return w, x, y, z
+	return w, x, y
 }

--- a/d2common/d2fileformats/d2pl2/pl2_color.go
+++ b/d2common/d2fileformats/d2pl2/pl2_color.go
@@ -5,6 +5,8 @@ const (
 	bitShift8
 	bitShift16
 	bitShift24
+
+	mask = 0xff
 )
 
 // PL2Color represents an RGBA color
@@ -15,14 +17,12 @@ type PL2Color struct {
 	_ uint8
 }
 
-const (
-	mask = 0xff
-)
-
+// RGBA returns RGBA values of PL2Color
 func (p *PL2Color) RGBA() uint32 {
 	return toComposite(p.R, p.G, p.B, mask)
 }
 
+// SetRGBA sets PL2Color's value to rgba given
 func (p *PL2Color) SetRGBA(rgba uint32) {
 	p.R, p.G, p.B, _ = toComponent(rgba)
 }

--- a/d2common/d2fileformats/d2pl2/pl2_color_24bits.go
+++ b/d2common/d2fileformats/d2pl2/pl2_color_24bits.go
@@ -14,5 +14,5 @@ func (p *PL2Color24Bits) RGBA() uint32 {
 
 // SetRGBA sets PL2Color's value to rgba given
 func (p *PL2Color24Bits) SetRGBA(rgba uint32) {
-	p.R, p.G, p.B, _ = toComponent(rgba)
+	p.R, p.G, p.B = toComponent(rgba)
 }

--- a/d2common/d2fileformats/d2pl2/pl2_color_24bits.go
+++ b/d2common/d2fileformats/d2pl2/pl2_color_24bits.go
@@ -6,3 +6,13 @@ type PL2Color24Bits struct {
 	G uint8
 	B uint8
 }
+
+// RGBA returns RGBA values of PL2Color
+func (p *PL2Color24Bits) RGBA() uint32 {
+	return toComposite(p.R, p.G, p.B, mask)
+}
+
+// SetRGBA sets PL2Color's value to rgba given
+func (p *PL2Color24Bits) SetRGBA(rgba uint32) {
+	p.R, p.G, p.B, _ = toComponent(rgba)
+}


### PR DESCRIPTION
Hi there,
HellSpawner's palette transform editor could use palette grid widget, but first, PL2Color should implement [PaletteColor](https://github.com/gucio321/HellSpawner/blob/d57f548e8e6a7fdbbab6e4f22530973c9b9d43f0/hswidget/palettegridwidget/palettecolor.go#L4)