### PR TITLE
Use filepath instead of path for Windows support

### DIFF
--- a/d2common/d2fileformats/d2mpq/mpq.go
+++ b/d2common/d2fileformats/d2mpq/mpq.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -201,5 +200,5 @@ func openIgnoreCase(mpqPath string) (*os.File, error) {
 		}
 	}
 
-	return os.Open(path.Join(mpqDir, mpqName)) //nolint:gosec // Will fix later
+	return os.Open(filepath.Join(mpqDir, mpqName)) //nolint:gosec // Will fix later
 }

--- a/d2core/d2config/d2config.go
+++ b/d2core/d2config/d2config.go
@@ -3,7 +3,6 @@ package d2config
 import (
 	"encoding/json"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -24,7 +23,7 @@ type Configuration struct {
 
 // Save saves the configuration object to disk
 func (c *Configuration) Save() error {
-	configDir := path.Dir(c.path)
+	configDir := filepath.Dir(c.path)
 	if err := os.MkdirAll(configDir, 0750); err != nil {
 		return err
 	}

--- a/d2core/d2config/default_directories.go
+++ b/d2core/d2config/default_directories.go
@@ -2,7 +2,7 @@ package d2config
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 )
 
 const (
@@ -16,7 +16,7 @@ const (
 // DefaultConfigPath returns the absolute path for the default config file location
 func DefaultConfigPath() string {
 	if configDir, err := os.UserConfigDir(); err == nil {
-		return path.Join(configDir, od2ConfigDirName, od2ConfigFileName)
+		return filepath.Join(configDir, od2ConfigDirName, od2ConfigFileName)
 	}
 
 	return LocalConfigPath()
@@ -24,5 +24,5 @@ func DefaultConfigPath() string {
 
 // LocalConfigPath returns the absolute path to the directory of the OpenDiablo2 executable
 func LocalConfigPath() string {
-	return path.Join(path.Dir(os.Args[0]), od2ConfigFileName)
+	return filepath.Join(filepath.Dir(os.Args[0]), od2ConfigFileName)
 }

--- a/d2core/d2config/defaults.go
+++ b/d2core/d2config/defaults.go
@@ -60,7 +60,7 @@ func DefaultConfig() *Configuration {
 		}
 	case "linux":
 		if usr, err := user.Current(); err == nil {
-			config.MpqPath = filepath.Join(usr.HomeDir, ".wine/drive_c/Program Files (x86)/Diablo II")
+			config.MpqPath = filepath.Join(usr.HomeDir, ".wine", "drive_c", "Program Files (x86)", "Diablo II")
 		}
 	}
 

--- a/d2core/d2config/defaults.go
+++ b/d2core/d2config/defaults.go
@@ -2,7 +2,7 @@ package d2config
 
 import (
 	"os/user"
-	"path"
+	"path/filepath"
 	"runtime"
 )
 
@@ -60,7 +60,7 @@ func DefaultConfig() *Configuration {
 		}
 	case "linux":
 		if usr, err := user.Current(); err == nil {
-			config.MpqPath = path.Join(usr.HomeDir, ".wine/drive_c/Program Files (x86)/Diablo II")
+			config.MpqPath = filepath.Join(usr.HomeDir, ".wine/drive_c/Program Files (x86)/Diablo II")
 		}
 	}
 

--- a/d2core/d2hero/hero_state_factory.go
+++ b/d2core/d2hero/hero_state_factory.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -82,7 +81,7 @@ func (f *HeroStateFactory) GetAllHeroStates() ([]*HeroState, error) {
 			continue
 		}
 
-		gameState := f.LoadHeroState(path.Join(basePath, file.Name()))
+		gameState := f.LoadHeroState(filepath.Join(basePath, file.Name()))
 		if gameState == nil || gameState.HeroType == d2enum.HeroNone {
 
 		} else if gameState.Stats == nil || gameState.Skills == nil {
@@ -224,7 +223,7 @@ func (f *HeroStateFactory) getGameBaseSavePath() (string, error) {
 		return "", err
 	}
 
-	return path.Join(configDir, "OpenDiablo2/Saves"), nil
+	return filepath.Join(configDir, "OpenDiablo2/Saves"), nil
 }
 
 func (f *HeroStateFactory) getFirstFreeFileName() string {
@@ -232,7 +231,7 @@ func (f *HeroStateFactory) getFirstFreeFileName() string {
 	basePath, _ := f.getGameBaseSavePath()
 
 	for {
-		filePath := path.Join(basePath, strconv.Itoa(i)+".od2")
+		filePath := filepath.Join(basePath, strconv.Itoa(i)+".od2")
 		if _, err := os.Stat(filePath); os.IsNotExist(err) {
 			return filePath
 		}
@@ -246,7 +245,7 @@ func (f *HeroStateFactory) Save(state *HeroState) error {
 		state.FilePath = f.getFirstFreeFileName()
 	}
 
-	if err := os.MkdirAll(path.Dir(state.FilePath), mkdirPermission); err != nil {
+	if err := os.MkdirAll(filepath.Dir(state.FilePath), mkdirPermission); err != nil {
 		return err
 	}
 

--- a/d2core/d2hero/hero_state_factory.go
+++ b/d2core/d2hero/hero_state_factory.go
@@ -223,7 +223,7 @@ func (f *HeroStateFactory) getGameBaseSavePath() (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(configDir, "OpenDiablo2/Saves"), nil
+	return filepath.Join(configDir, "OpenDiablo2", "Saves"), nil
 }
 
 func (f *HeroStateFactory) getFirstFreeFileName() string {

--- a/d2game/d2gamescreen/credits.go
+++ b/d2game/d2gamescreen/credits.go
@@ -72,7 +72,7 @@ type Credits struct {
 
 // LoadContributors loads the contributors data from file
 func (v *Credits) LoadContributors() []string {
-	file, err := os.Open(filepath.Join("./", "CONTRIBUTORS"))
+	file, err := os.Open(filepath.Join(".", "CONTRIBUTORS"))
 	if err != nil || file == nil {
 		v.Warning("CONTRIBUTORS file is missing")
 		return []string{"MISSING CONTRIBUTOR FILES!"}

--- a/d2game/d2gamescreen/credits.go
+++ b/d2game/d2gamescreen/credits.go
@@ -3,7 +3,7 @@ package d2gamescreen
 import (
 	"bufio"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2common/d2enum"
@@ -72,7 +72,7 @@ type Credits struct {
 
 // LoadContributors loads the contributors data from file
 func (v *Credits) LoadContributors() []string {
-	file, err := os.Open(path.Join("./", "CONTRIBUTORS"))
+	file, err := os.Open(filepath.Join("./", "CONTRIBUTORS"))
 	if err != nil || file == nil {
 		v.Warning("CONTRIBUTORS file is missing")
 		return []string{"MISSING CONTRIBUTOR FILES!"}


### PR DESCRIPTION
The current build fails to create the `OpenDiablo2` directory on Windows without this change.

In contrast to `path`, `path/filepath` is OS-aware and handles Windows path separators correctly.