### PR TITLE
Auto Author Assign

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,13 @@
+name: 'Auto Author Assign'
+
+on:
+    pull_request_target:
+        types: [opened, reopened]
+
+jobs:
+    assign-author:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: toshimaru/auto-author-assign@v1.2.0
+              with:
+                  repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
In most cases, pull request author should be assigned as assignee of the pull request. This action automatically assigns PR author as an assignee.