### PR TITLE
Fix golang-ci gocritic error

### DIFF
--- a/d2common/d2fileformats/d2mpq/mpq.go
+++ b/d2common/d2fileformats/d2mpq/mpq.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -181,24 +182,26 @@ func (mpq *MPQ) Size() uint32 {
 func openIgnoreCase(mpqPath string) (*os.File, error) {
 	// First see if file exists with specified case
 	mpqFile, err := os.Open(mpqPath) //nolint:gosec // Will fix later
-	if err == nil {
-		return mpqFile, err
-	}
-
-	mpqName := filepath.Base(mpqPath)
-	mpqDir := filepath.Dir(mpqPath)
-
-	files, err := ioutil.ReadDir(mpqDir)
 	if err != nil {
-		return nil, err
-	}
+		mpqName := filepath.Base(mpqPath)
+		mpqDir := filepath.Dir(mpqPath)
 
-	for _, file := range files {
-		if strings.EqualFold(file.Name(), mpqName) {
-			mpqName = file.Name()
-			break
+		var files []fs.FileInfo
+		files, err = ioutil.ReadDir(mpqDir)
+
+		if err != nil {
+			return nil, err
 		}
+
+		for _, file := range files {
+			if strings.EqualFold(file.Name(), mpqName) {
+				mpqName = file.Name()
+				break
+			}
+		}
+
+		return os.Open(filepath.Join(mpqDir, mpqName)) //nolint:gosec // Will fix later
 	}
 
-	return os.Open(filepath.Join(mpqDir, mpqName)) //nolint:gosec // Will fix later
+	return mpqFile, err
 }


### PR DESCRIPTION
CI currently is broken. 
See: https://app.circleci.com/pipelines/github/OpenDiablo2/OpenDiablo2/1703/workflows/f7f2b2dd-c07a-4541-99b4-21313718cfba/jobs/1704

This PR it should fix this error:

```
d2common/d2fileformats/d2mpq/mpq.go:185:3: nilValReturn: returned expr is always nil; replace err with nil (gocritic)
        return mpqFile, err
```