### PR TITLE
Bump go.mod Go version to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OpenDiablo2/OpenDiablo2
 
-go 1.14
+go 1.16
 
 require (
 	github.com/JoshVarga/blast v0.0.0-20180421040937-681c804fb9f0


### PR DESCRIPTION
`io/fs` requires Go 1.16. The `go.mod` file should state this to avoid confusion.
