### PR TITLE
d2ds1: bugfixes

### DIFF
--- a/d2common/d2fileformats/d2ds1/ds1_layers.go
+++ b/d2common/d2fileformats/d2ds1/ds1_layers.go
@@ -132,7 +132,7 @@ func (l *ds1Layers) push(t LayerGroupType, layer *Layer) {
 
 	group := l.getLayersGroup(t)
 
-	max := getMaxGroupLen(t)
+	max := GetMaxGroupLen(t)
 
 	if len(*group) < max {
 		*group = append(*group, layer)
@@ -194,7 +194,7 @@ func (l *ds1Layers) insert(t LayerGroupType, idx int, newLayer *Layer) {
 		return
 	}
 
-	if len(*group)+1 > getMaxGroupLen(t) {
+	if len(*group)+1 > GetMaxGroupLen(t) {
 		return
 	}
 
@@ -335,7 +335,8 @@ func (l *ds1Layers) getLayersGroup(t LayerGroupType) (group *layerGroup) {
 	return group
 }
 
-func getMaxGroupLen(t LayerGroupType) (max int) {
+// GetMaxGroupLen returns maximum length of layer group of type given
+func GetMaxGroupLen(t LayerGroupType) (max int) {
 	switch t {
 	case FloorLayerGroup:
 		max = maxFloorLayers

--- a/d2common/d2fileformats/d2ds1/ds1_layers.go
+++ b/d2common/d2fileformats/d2ds1/ds1_layers.go
@@ -15,7 +15,7 @@ const (
 	FloorLayerGroup LayerGroupType = iota
 	WallLayerGroup
 	ShadowLayerGroup
-	Substitutionlayergroup
+	SubstitutionLayerGroup
 )
 
 type layerGroup []*Layer
@@ -51,7 +51,7 @@ func (l *ds1Layers) cull() {
 	l.cullNilLayers(FloorLayerGroup)
 	l.cullNilLayers(WallLayerGroup)
 	l.cullNilLayers(ShadowLayerGroup)
-	l.cullNilLayers(Substitutionlayergroup)
+	l.cullNilLayers(SubstitutionLayerGroup)
 }
 
 // removes nil layers of given layer group type
@@ -89,7 +89,7 @@ func (l *ds1Layers) SetSize(w, h int) {
 	l.enforceSize(FloorLayerGroup)
 	l.enforceSize(WallLayerGroup)
 	l.enforceSize(ShadowLayerGroup)
-	l.enforceSize(Substitutionlayergroup)
+	l.enforceSize(SubstitutionLayerGroup)
 }
 
 func (l *ds1Layers) enforceSize(t LayerGroupType) {
@@ -298,20 +298,20 @@ func (l *ds1Layers) DeleteShadow(idx int) {
 }
 
 func (l *ds1Layers) GetSubstitution(idx int) *Layer {
-	return l.get(Substitutionlayergroup, idx)
+	return l.get(SubstitutionLayerGroup, idx)
 }
 
 func (l *ds1Layers) PushSubstitution(sub *Layer) *ds1Layers {
-	l.push(Substitutionlayergroup, sub)
+	l.push(SubstitutionLayerGroup, sub)
 	return l
 }
 
 func (l *ds1Layers) PopSubstitution() *Layer {
-	return l.pop(Substitutionlayergroup)
+	return l.pop(SubstitutionLayerGroup)
 }
 
 func (l *ds1Layers) InsertSubstitution(idx int, newSubstitution *Layer) {
-	l.insert(Substitutionlayergroup, idx, newSubstitution)
+	l.insert(SubstitutionLayerGroup, idx, newSubstitution)
 }
 
 func (l *ds1Layers) DeleteSubstitution(idx int) {
@@ -326,7 +326,7 @@ func (l *ds1Layers) getLayersGroup(t LayerGroupType) (group *layerGroup) {
 		group = &l.Walls
 	case ShadowLayerGroup:
 		group = &l.Shadows
-	case Substitutionlayergroup:
+	case SubstitutionLayerGroup:
 		group = &l.Substitutions
 	default:
 		return nil
@@ -343,7 +343,7 @@ func getMaxGroupLen(t LayerGroupType) (max int) {
 		max = maxWallLayers
 	case ShadowLayerGroup:
 		max = maxShadowLayers
-	case Substitutionlayergroup:
+	case SubstitutionLayerGroup:
 		max = maxSubstitutionLayers
 	default:
 		return 0

--- a/d2common/d2fileformats/d2ds1/ds1_layers.go
+++ b/d2common/d2fileformats/d2ds1/ds1_layers.go
@@ -81,9 +81,9 @@ func (l *ds1Layers) cullNilLayers(t LayerGroupType) {
 	// exit culling procedure when no nil layers are found in entire group.
 culling:
 	for {
-		for idx := len(*group) - 1; idx > 0; idx-- {
+		for idx := len(*group) - 1; idx >= 0; idx-- {
 			if (*group)[idx] == nil {
-				*group = (*group)[:idx]
+				*group = append((*group)[:idx], (*group)[idx+1:]...)
 				continue culling
 			}
 		}

--- a/d2common/d2fileformats/d2ds1/ds1_layers.go
+++ b/d2common/d2fileformats/d2ds1/ds1_layers.go
@@ -18,6 +18,22 @@ const (
 	SubstitutionLayerGroup
 )
 
+func (l LayerGroupType) String() string {
+	switch l {
+	case FloorLayerGroup:
+		return "floor"
+	case WallLayerGroup:
+		return "wall"
+	case ShadowLayerGroup:
+		return "shadow"
+	case SubstitutionLayerGroup:
+		return "substitution"
+	}
+
+	// should not be reached
+	return "unknown"
+}
+
 type layerGroup []*Layer
 
 type ds1Layers struct {

--- a/d2common/d2fileformats/d2ds1/ds1_layers.go
+++ b/d2common/d2fileformats/d2ds1/ds1_layers.go
@@ -56,7 +56,7 @@ func (l *ds1Layers) cull() {
 
 // removes nil layers of given layer group type
 func (l *ds1Layers) cullNilLayers(t LayerGroupType) {
-	group := l.getLayersGroup(t)
+	group := l.GetLayersGroup(t)
 	if group == nil {
 		return
 	}
@@ -96,7 +96,7 @@ func (l *ds1Layers) enforceSize(t LayerGroupType) {
 	l.ensureInit()
 	l.cull()
 
-	group := l.getLayersGroup(t)
+	group := l.GetLayersGroup(t)
 	if group == nil {
 		return
 	}
@@ -130,7 +130,7 @@ func (l *ds1Layers) push(t LayerGroupType, layer *Layer) {
 	l.cull()
 	layer.SetSize(l.Size())
 
-	group := l.getLayersGroup(t)
+	group := l.GetLayersGroup(t)
 
 	max := GetMaxGroupLen(t)
 
@@ -144,7 +144,7 @@ func (l *ds1Layers) pop(t LayerGroupType) *Layer {
 	l.ensureInit()
 	l.cull()
 
-	group := l.getLayersGroup(t)
+	group := l.GetLayersGroup(t)
 	if group == nil {
 		return nil
 	}
@@ -167,7 +167,7 @@ func (l *ds1Layers) get(t LayerGroupType, idx int) *Layer {
 	l.ensureInit()
 	l.cull()
 
-	group := l.getLayersGroup(t)
+	group := l.GetLayersGroup(t)
 	if group == nil {
 		return nil
 	}
@@ -189,7 +189,7 @@ func (l *ds1Layers) insert(t LayerGroupType, idx int, newLayer *Layer) {
 
 	newLayer.SetSize(l.Size())
 
-	group := l.getLayersGroup(t)
+	group := l.GetLayersGroup(t)
 	if group == nil {
 		return
 	}
@@ -220,7 +220,7 @@ func (l *ds1Layers) delete(t LayerGroupType, idx int) {
 	l.ensureInit()
 	l.cull()
 
-	group := l.getLayersGroup(t)
+	group := l.GetLayersGroup(t)
 	if group == nil {
 		return
 	}
@@ -318,7 +318,8 @@ func (l *ds1Layers) DeleteSubstitution(idx int) {
 	l.delete(ShadowLayerGroup, idx)
 }
 
-func (l *ds1Layers) getLayersGroup(t LayerGroupType) (group *layerGroup) {
+// GetLayersGroup returns layer group depending on type given
+func (l *ds1Layers) GetLayersGroup(t LayerGroupType) (group *layerGroup) {
 	switch t {
 	case FloorLayerGroup:
 		group = &l.Floors

--- a/d2common/d2fileformats/d2ds1/ds1_layers_test.go
+++ b/d2common/d2fileformats/d2ds1/ds1_layers_test.go
@@ -131,7 +131,7 @@ func ds1LayersInsert(t *testing.T, lt LayerGroupType) {
 
 	var insert func(i int)
 
-	group := ds1.getLayersGroup(lt)
+	group := ds1.GetLayersGroup(lt)
 
 	switch lt {
 	case FloorLayerGroup:

--- a/d2common/d2fileformats/d2ds1/ds1_layers_test.go
+++ b/d2common/d2fileformats/d2ds1/ds1_layers_test.go
@@ -116,7 +116,7 @@ func Test_ds1Layers_Insert(t *testing.T) {
 func ds1LayersInsert(t *testing.T, lt LayerGroupType) {
 	ds1 := DS1{}
 
-	layers := make([]*Layer, getMaxGroupLen(lt)+1)
+	layers := make([]*Layer, GetMaxGroupLen(lt)+1)
 
 	for i := range layers {
 		i := i
@@ -150,7 +150,7 @@ func ds1LayersInsert(t *testing.T, lt LayerGroupType) {
 		insert(i)
 	}
 
-	if len(*group) != getMaxGroupLen(lt) {
+	if len(*group) != GetMaxGroupLen(lt) {
 		t.Fatal("unexpected floor len after setting")
 	}
 

--- a/d2common/d2fileformats/d2ds1/ds1_layers_test.go
+++ b/d2common/d2fileformats/d2ds1/ds1_layers_test.go
@@ -15,7 +15,7 @@ func Test_ds1Layers_Delete(t *testing.T) {
 		ds1LayersDelete(t, ShadowLayerGroup)
 	})
 	t.Run("Substitution", func(t *testing.T) {
-		ds1LayersDelete(t, Substitutionlayergroup)
+		ds1LayersDelete(t, SubstitutionLayerGroup)
 	})
 }
 
@@ -42,7 +42,7 @@ func ds1LayersDelete(t *testing.T, lt LayerGroupType) {
 		del = func(i int) { ds1.DeleteWall(0) }
 	case ShadowLayerGroup:
 		del = func(i int) { ds1.DeleteShadow(0) }
-	case Substitutionlayergroup:
+	case SubstitutionLayerGroup:
 		del = func(i int) { ds1.DeleteSubstitution(0) }
 	default:
 		t.Fatal("unknown layer type given")
@@ -67,7 +67,7 @@ func Test_ds1Layers_Get(t *testing.T) {
 		ds1LayersGet(t, ShadowLayerGroup)
 	})
 	t.Run("Substitution", func(t *testing.T) {
-		ds1LayersGet(t, Substitutionlayergroup)
+		ds1LayersGet(t, SubstitutionLayerGroup)
 	})
 }
 
@@ -83,7 +83,7 @@ func ds1LayersGet(t *testing.T, lt LayerGroupType) {
 		get = func(i int) *Layer { return ds1.GetWall(0) }
 	case ShadowLayerGroup:
 		get = func(i int) *Layer { return ds1.GetShadow(0) }
-	case Substitutionlayergroup:
+	case SubstitutionLayerGroup:
 		get = func(i int) *Layer { return ds1.GetSubstitution(0) }
 	default:
 		t.Fatal("unknown layer type given")
@@ -93,7 +93,7 @@ func ds1LayersGet(t *testing.T, lt LayerGroupType) {
 	layer := get(0)
 
 	// example has nil substitution layer, maybe we need another test
-	if layer == nil && lt != Substitutionlayergroup {
+	if layer == nil && lt != SubstitutionLayerGroup {
 		t.Errorf("layer expected")
 	}
 }
@@ -109,7 +109,7 @@ func Test_ds1Layers_Insert(t *testing.T) {
 		ds1LayersInsert(t, ShadowLayerGroup)
 	})
 	t.Run("Substitution", func(t *testing.T) {
-		ds1LayersInsert(t, Substitutionlayergroup)
+		ds1LayersInsert(t, SubstitutionLayerGroup)
 	})
 }
 
@@ -140,7 +140,7 @@ func ds1LayersInsert(t *testing.T, lt LayerGroupType) {
 		insert = func(i int) { ds1.InsertWall(0, layers[i]) }
 	case ShadowLayerGroup:
 		insert = func(i int) { ds1.InsertShadow(0, layers[i]) }
-	case Substitutionlayergroup:
+	case SubstitutionLayerGroup:
 		insert = func(i int) { ds1.InsertSubstitution(0, layers[i]) }
 	default:
 		t.Fatal("unknown layer type given")
@@ -177,7 +177,7 @@ func Test_ds1Layers_Pop(t *testing.T) {
 	})
 
 	t.Run("Substitution", func(t *testing.T) {
-		ds1layerPop(Substitutionlayergroup, t)
+		ds1layerPop(SubstitutionLayerGroup, t)
 	})
 }
 
@@ -213,7 +213,7 @@ func ds1layerPop(lt LayerGroupType, t *testing.T) {
 
 			return l
 		}
-	case Substitutionlayergroup:
+	case SubstitutionLayerGroup:
 		numBefore = len(ds1.Substitutions)
 		pop = func() *Layer {
 			l := ds1.PopSubstitution()
@@ -257,7 +257,7 @@ func Test_ds1Layers_Push(t *testing.T) {
 	})
 
 	t.Run("Substitution", func(t *testing.T) {
-		ds1layerPush(Substitutionlayergroup, t)
+		ds1layerPush(SubstitutionLayerGroup, t)
 	})
 }
 
@@ -306,7 +306,7 @@ func ds1layerPush(lt LayerGroupType, t *testing.T) { //nolint:funlen // no biggi
 		get = layers.GetShadow
 		max = maxShadowLayers
 		group = &layers.Shadows
-	case Substitutionlayergroup:
+	case SubstitutionLayerGroup:
 		push = func() { layers.PushSubstitution(&Layer{}) }
 		get = layers.GetSubstitution
 		max = maxSubstitutionLayers


### PR DESCRIPTION
Hi there,
I actually work on ds1 editor in **HellSpawner**
This PR contains minor fixes for d2ds1 package

fixes:
- rename: Substitutionlayergroup -> SubstitutionLayerGroup (looks better)
- the following types/methods are now public:
  - getMaxGroupLen
  - getLayersGroup
- fixed bug, when cullNilLayers worked incorrectly