### PR TITLE
d2ds1: fixed bug, when the file was encoded incorrectly

### DIFF
--- a/d2common/d2fileformats/d2ds1/ds1.go
+++ b/d2common/d2fileformats/d2ds1/ds1.go
@@ -572,7 +572,7 @@ func (ds1 *DS1) Marshal() []byte {
 		sw.PushInt32(int32(len(ds1.Walls)))
 
 		if ds1.version.specifiesFloors() {
-			sw.PushInt32(int32(len(ds1.Walls)))
+			sw.PushInt32(int32(len(ds1.Floors)))
 		}
 	}
 


### PR DESCRIPTION
Hi there,
when version was greater than 16, the file was encoded incorrectly