### PR TITLE
golangci-lint: update config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,8 +32,6 @@ linters-settings:
       # to possibly non-intuitive layout of struct fields (harder to read). Disable
       # `fieldalignment` check here until we evaluate if it is worthwhile.
       - fieldalignment
-      # https://github.com/golangci/golangci-lint/issues/1973
-      - sigchanyzer
   lll:
     line-length: 140
   misspell:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,6 @@ linters:
     - godox
     - gofmt
     - goimports
-    - golint
     - gomnd
     - goprintffuncname
     - gosec

--- a/d2app/app.go
+++ b/d2app/app.go
@@ -141,7 +141,9 @@ func (a *App) startDedicatedServer() error {
 		return srvErr
 	}
 
-	c := make(chan os.Signal)
+	// We must use a buffered channel or risk missing the signal
+	// if we're not ready to receive when the signal is sent.
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM) // This traps Control-c to safely shut down the server
 
 	go func() {


### PR DESCRIPTION
hi there!
there is a new golangci-lint version ([v1.40.1](https://github.com/golangci/golangci-lint/releases/tag/v1.40.1))
changes:
- https://github.com/golangci/golangci-lint/issues/1973 was fixed
- `golint` was deprecated by golang developers